### PR TITLE
Enable UART during initialization on Zynq7000 platform

### DIFF
--- a/elfloader-tool/src/arch-arm/boot.c
+++ b/elfloader-tool/src/arch-arm/boot.c
@@ -85,9 +85,9 @@ void main(void)
 #endif
 
     /* Print welcome message. */
+    platform_init();
     printf("\nELF-loader started on ");
     print_cpuid();
-    platform_init();
 
     printf("  paddr=[%p..%p]\n", _start, _end - 1);
 

--- a/elfloader-tool/src/arch-arm/plat-zynq7000/platform_init.c
+++ b/elfloader-tool/src/arch-arm/plat-zynq7000/platform_init.c
@@ -9,6 +9,7 @@
  */
 
 #include "../elfloader.h"
+#include "sys_fputc.h"
 
 #define MPCORE_PRIV               0xF8F00000
 
@@ -70,5 +71,6 @@ void remap_ram(void)
 void platform_init(void)
 {
     remap_ram();
+    enable_uart();
 }
 

--- a/elfloader-tool/src/arch-arm/plat-zynq7000/sys_fputc.c
+++ b/elfloader-tool/src/arch-arm/plat-zynq7000/sys_fputc.c
@@ -40,6 +40,9 @@
 #define UART_INTRPT_MASK_TXEMPTY     (1U << 3)
 #define UART_CHANNEL_STS_TXEMPTY     (1U << 3)
 
+#define UART_CONTROL_TX_EN           (1U << 4)
+#define UART_CONTROL_TX_DIS          (1U << 5)
+
 
 #define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
 
@@ -58,4 +61,13 @@ __fputc(int c, FILE *stream)
     }
 
     return 0;
+}
+
+void
+enable_uart()
+{
+    uint32_t v = *UART_REG(UART_CONTROL);
+    v |= UART_CONTROL_TX_EN;
+    v &= ~UART_CONTROL_TX_DIS;
+    *UART_REG(UART_CONTROL) = v;
 }

--- a/elfloader-tool/src/arch-arm/plat-zynq7000/sys_fputc.h
+++ b/elfloader-tool/src/arch-arm/plat-zynq7000/sys_fputc.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014, NICTA
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(NICTA_GPL)
+ */
+
+#ifndef _SYS_FPUTC_H_
+#define _SYS_FPUTC_H_
+
+void enable_uart(void);
+
+#endif /* _SYS_FPUTC_H_ */
+

--- a/elfloader-tool/src/arch-arm/plat-zynq7000/sys_fputc.h
+++ b/elfloader-tool/src/arch-arm/plat-zynq7000/sys_fputc.h
@@ -1,11 +1,13 @@
 /*
- * Copyright 2014, NICTA
+ * Copyright 2016, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
  *
  * This software may be distributed and modified according to the terms of
  * the GNU General Public License version 2. Note that NO WARRANTY is provided.
  * See "LICENSE_GPLv2.txt" for details.
  *
- * @TAG(NICTA_GPL)
+ * @TAG(D61_GPL)
  */
 
 #ifndef _SYS_FPUTC_H_


### PR DESCRIPTION
The Zynq7000 UART is not initialized by default. On real hardware U-boot
will perform the correct initialization, but in QEMU there is no
initialization done. This commit enables the UART in elfloader so that
it will work both on the hardware and in QEMU.