### PR TITLE
Calling cc-option, etc, with the configured compiler

### DIFF
--- a/common-tool/Makefile.flags
+++ b/common-tool/Makefile.flags
@@ -26,22 +26,27 @@ NK_ASFLAGS =
 
 NK_CCFLAGS =
 
-ldflags-y += $(call cc-ldoption, -Wl$(comma)--build-id=none)
+LDFLAGS += $(call cc-ldoption, $(K_CC), -Wl$(comma)--build-id=none)
+NK_LDFLAGS += $(call cc-ldoption, $(NK_CC), -Wl$(comma)--build-id=none)
 
 ifeq ($(CONFIG_ARCH_X86),y)
-	ccflags-y += $(call cc-option,-fno-stack-protector)
+	CCFLAGS += $(call cc-option, $(K_CC), -fno-stack-protector)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -fno-stack-protector)
 	export ARCH = x86
 	DEFINES += ARCH_X86
 	export ARCH_X86
 	export RUST_ENDIAN = little
 	export RUST_ENV = gnu
-	ccflags-y += $(call cc-option,-fno-pic)
+	CCFLAGS += $(call cc-option, $(K_CC), -fno-pic)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -fno-pic)
 	ldflags-y += -static
 endif
 
 ifeq ($(CONFIG_ARCH_ARM),y)
-	ccflags-y += $(call cc-option,-marm)
-	ccflags-y += $(call cc-option,-Wtrampolines)
+	CCFLAGS += $(call cc-option, $(K_CC), -marm)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -marm)
+	CCFLAGS += $(call cc-option, $(K_CC), -Wtrampolines)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -Wtrampolines)
 	export ARCH = arm
 	DEFINES += ARCH_ARM
 	export ARCH_ARM
@@ -50,7 +55,8 @@ ifeq ($(CONFIG_ARCH_ARM),y)
 endif
 
 ifeq ($(CONFIG_ARCH_IA32),y)
-	ccflags-y += $(call cc-option,-m32)
+	CCFLAGS += $(call cc-option, $(K_CC), -m32)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -m32)
 
 	ldflags-y += -Wl,-m,elf_i386
 	asflags-y += -Wa,--32
@@ -71,8 +77,10 @@ ifeq ($(CONFIG_ARCH_IA32),y)
 endif
 
 ifeq ($(CONFIG_ARCH_X86_64),y)
-	cflags-y += $(call cc-option,-m64)
-	cflags-y += $(call cc-option, -fno-asynchronous-unwind-tables,)
+	CFLAGS += $(call cc-option, $(K_CC), -m64)
+	NK_CFLAGS += $(call cc-option, $(NK_CC), -m64)
+	CFLAGS += $(call cc-option, $(K_CC), -fno-asynchronous-unwind-tables,)
+	NK_CFLAGS += $(call cc-option, $(NK_CC), -fno-asynchronous-unwind-tables,)
 	ldflags-y  += -Wl,-m -Wl,elf_x86_64
 	asflags-y  += -Wa,--64
 	NK_LDFLAGS += -Wl,-m -Wl,elf_x86_64
@@ -147,8 +155,10 @@ ifeq ($(CONFIG_ARCH_AARCH64),y)
 endif
 
 ifeq ($(CONFIG_ARM1136JF_S),y)
-	ccflags-y += $(call cc-option,-mcpu=arm1136jf-s,-march=armv6)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=arm1136jf-s, -Wa$(comma)-march=armv6)
+	CCFLAGS += $(call cc-option, $(K_CC), -mcpu=arm1136jf-s, -march=armv6)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mcpu=arm1136jf-s, -march=armv6)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=arm1136jf-s, -Wa$(comma)-march=armv6)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=arm1136jf-s, -Wa$(comma)-march=armv6)
 	DEFINES += ARMV6
 	DEFINES += ARM1136J_S
 	export RUST_CPU = arm1136jf-s
@@ -159,8 +169,10 @@ endif
 
 
 ifeq ($(CONFIG_ARM_CORTEX_A7),y)
-	ccflags-y += $(call cc-option, -mcpu=cortex-a7,-march=armv7-a)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=cortex-a7, -Wa$(comma)-march=armv7-a)
+	CCFLAGS += $(call cc-option, $(K_CC), -mcpu=cortex-a7, -march=armv7-a)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mcpu=cortex-a7, -march=armv7-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=cortex-a7, -Wa$(comma)-march=armv7-a)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=cortex-a7, -Wa$(comma)-march=armv7-a)
 	DEFINES += ARMV7_A
 	DEFINES += ARM_CORTEX_A7
 	export ARMV=armv7-a
@@ -168,8 +180,10 @@ ifeq ($(CONFIG_ARM_CORTEX_A7),y)
 endif
 
 ifeq ($(CONFIG_ARM_CORTEX_A8),y)
-	ccflags-y += $(call cc-option, -mcpu=cortex-a8,-march=armv7-a)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=cortex-a8, -Wa$(comma)-march=armv7-a)
+	CCFLAGS += $(call cc-option, $(K_CC), -mcpu=cortex-a8,-march=armv7-a)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mcpu=cortex-a8,-march=armv7-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=cortex-a8, -Wa$(comma)-march=armv7-a)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=cortex-a8, -Wa$(comma)-march=armv7-a)
 	DEFINES += ARMV7_A
 	DEFINES += ARM_CORTEX_A8
 	export ARMV=armv7-a
@@ -179,8 +193,10 @@ ifeq ($(CONFIG_ARM_CORTEX_A8),y)
 endif
 
 ifeq ($(CONFIG_ARM_CORTEX_A9),y)
-	ccflags-y += $(call cc-option, -mcpu=cortex-a9, -march=armv7-a)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=cortex-a9, -Wa$(comma)-march=armv7-a)
+	CCFLAGS += $(call cc-option, $(K_CC), -mcpu=cortex-a9, -march=armv7-a)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mcpu=cortex-a9, -march=armv7-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=cortex-a9, -Wa$(comma)-march=armv7-a)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=cortex-a9, -Wa$(comma)-march=armv7-a)
 	DEFINES += ARMV7_A
 	DEFINES += ARM_CORTEX_A9
 	export ARMV=armv7-a
@@ -190,11 +206,16 @@ ifeq ($(CONFIG_ARM_CORTEX_A9),y)
 endif
 
 ifeq ($(CONFIG_ARM_CORTEX_A15),y)
-	ccflags-y += $(call cc-option, -mtune=cortex-a15,)
-	asflags-y += $(call as-option, -Wa$(comma)-mtune=cortex-a15,)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=cortex-a15,)
-	ccflags-y += $(call cc-option,-march=armv7ve,-march=armv7-a)
-	asflags-y += $(call as-option,-Wa$(comma)-march=armv7ve,-Wa$(comma)-march=armv7-a)
+	CCFLAGS += $(call cc-option, $(K_CC), -mtune=cortex-a15,)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mtune=cortex-a15,)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mtune=cortex-a15,)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mtune=cortex-a15,)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=cortex-a15,)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=cortex-a15,)
+	CCFLAGS += $(call cc-option, $(K_CC), -march=armv7ve, -march=armv7-a)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -march=armv7ve, -march=armv7-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-march=armv7ve, -Wa$(comma)-march=armv7-a)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-march=armv7ve, -Wa$(comma)-march=armv7-a)
 	DEFINES += ARMV7_A
 	DEFINES += ARM_CORTEX_A15
 	export ARMV=armv7-a
@@ -204,11 +225,16 @@ ifeq ($(CONFIG_ARM_CORTEX_A15),y)
 endif
 
 ifeq ($(CONFIG_ARM_CORTEX_A53),y)
-	ccflags-y += $(call cc-option, -mtune=cortex-a53)
-	ccflags-y += $(call cc-option, -march=armv8-a)
-	asflags-y += $(call as-option, -Wa$(comma)-march=armv8-a)
-	asflags-y += $(call as-option, -Wa$(comma)-mtune=cortex-a53)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=cortex-a53)
+	CCFLAGS += $(call cc-option, $(K_CC), -mtune=cortex-a53)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mtune=cortex-a53)
+	CCFLAGS += $(call cc-option, $(K_CC), -march=armv8-a)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -march=armv8-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-march=armv8-a)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-march=armv8-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mtune=cortex-a53)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mtune=cortex-a53)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=cortex-a53)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=cortex-a53)
 	DEFINES += ARMV8_A
 	DEFINES += ARM_CORTEX_A53
 	export ARMV=armv8-a
@@ -218,11 +244,16 @@ ifeq ($(CONFIG_ARM_CORTEX_A53),y)
 endif
 
 ifeq ($(CONFIG_ARM_CORTEX_A57),y)
-	ccflags-y += $(call cc-option, -mtune=cortex-a57)
-	ccflags-y += $(call cc-option, -march=armv8-a)
-	asflags-y += $(call as-option, -Wa$(comma)-march=armv8-a)
-	asflags-y += $(call as-option, -Wa$(comma)-mtune=cortex-a57)
-	asflags-y += $(call as-option, -Wa$(comma)-mcpu=cortex-a57)
+	CCFLAGS += $(call cc-option, $(K_CC), -mtune=cortex-a57)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -mtune=cortex-a57)
+	CCFLAGS += $(call cc-option, $(K_CC), -march=armv8-a)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -march=armv8-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-march=armv8-a)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-march=armv8-a)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mtune=cortex-a57)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mtune=cortex-a57)
+	ASFLAGS += $(call as-option, $(K_CC), -Wa$(comma)-mcpu=cortex-a57)
+	NK_ASFLAGS += $(call as-option, $(NK_CC), -Wa$(comma)-mcpu=cortex-a57)
 	DEFINES += ARMV8_A
 	DEFINES += ARM_CORTEX_A57
 	export ARMV=armv8-a
@@ -352,7 +383,7 @@ endif
 # Kernel debugging.
 ifeq ($(CONFIG_DEBUG_BUILD),y)
 	# Set CFLAGS because we only want this to go to the kernel build system, not user
-	CFLAGS += $(call cc-option,-g)
+	CFLAGS += $(call cc-option,$(K_CC),-g)
 	DEFINES += DEBUG
 	DEFINES += SEL4_DEBUG_KERNEL
 	export DEBUG=1
@@ -360,18 +391,18 @@ endif
 
 # Userspace debugging.
 ifeq (${CONFIG_USER_DEBUG_INFO},y)
-	NK_CCFLAGS += $(call cc-option,-g3,-g) $(call cc-option,-ggdb3,-ggdb) $(call cc-option,-save-temps,)
+	NK_CCFLAGS += $(call cc-option,$(NK_CC),-g3,-g) $(call cc-option,$(NK_CC),-ggdb3,-ggdb) $(call cc-option,$(NK_CC),-save-temps,)
 endif
 
 ifeq (${CONFIG_USER_DEBUG_BUILD},y)
-	NK_CCFLAGS += $(call cc-option, -g)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -g)
 else
 	DEFINES += NDEBUG
 endif
 
 ifeq (${CONFIG_USER_LINKER_GC_SECTIONS},y)
-	NK_CCFLAGS += $(call cc-option, -ffunction-sections)
-	NK_CCFLAGS += $(call cc-option, -fdata-sections)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -ffunction-sections)
+	NK_CCFLAGS += $(call cc-option, $(NK_CC), -fdata-sections)
 	NK_LDFLAGS += -Wl,--gc-sections
 endif
 

--- a/common-tool/common.mk
+++ b/common-tool/common.mk
@@ -83,7 +83,7 @@ ENDGROUP := -Wl,--end-group
 
 ifeq (${CONFIG_USER_CFLAGS},)
     CFLAGS += $(WARNINGS:%=-W%) -nostdinc -std=gnu11
-    CXXFLAGS += $(WARNINGS:%=-W%) -nostdinc $(call cc-option,-std=gnu++14,-std=gnu++98)
+    CXXFLAGS += $(WARNINGS:%=-W%) -nostdinc $(call cc-option,$(K_CC),-std=gnu++14,-std=gnu++98)
 
     ifeq (${CONFIG_USER_OPTIMISATION_Os},y)
         CFLAGS += -Os

--- a/common-tool/project.mk
+++ b/common-tool/project.mk
@@ -173,6 +173,34 @@ MAKEFLAGS	+= -rR
 
 export HOSTCC HOSTCFLAGS MAKEFLAGS
 
+# Kernel cc-option compiler
+K_CC =
+ifdef CONFIG_KERNEL_COMPILER
+ifneq (${CONFIG_KERNEL_COMPILER},)
+ifneq (${CONFIG_KERNEL_COMPILER},"")
+K_CC = ${CONFIG_KERNEL_COMPILER}
+endif
+endif
+endif
+ifeq (${K_CC},)
+K_CC = ${CONFIG_CROSS_COMPILER_PREFIX:"%"=%}gcc
+endif
+
+# Non-kernel cc-option compiler
+NK_CC =
+ifdef CONFIG_USER_COMPILER
+ifneq (${CONFIG_USER_COMPILER},)
+ifneq (${CONFIG_USER_COMPILER},"")
+NK_CC = ${CONFIG_USER_COMPILER}
+endif
+endif
+endif
+ifeq (${NK_CC},)
+NK_CC = ${CONFIG_CROSS_COMPILER_PREFIX:"%"=%}gcc
+endif
+
+export K_CC NK_CC
+
 AS	= $(CROSS_COMPILE)as
 CC	= ${CCACHE} $(CROSS_COMPILE)gcc
 LD	= $(CROSS_COMPILE)ld -nostdlib

--- a/kbuild-tool/Kbuild.include
+++ b/kbuild-tool/Kbuild.include
@@ -101,32 +101,32 @@ try-run = $(shell set -e;		\
 	rm -f "$$TMP" "$$TMPO")
 
 # as-option
-# Usage: cflags-y += $(call as-option,-Wa$(comma)-isa=foo,)
+# Usage: cflags-y += $(call as-option, <compiler>, -Wa$(comma)-isa=foo,)
 
 as-option = $(call try-run,\
-	$(CC) $(KBUILD_CFLAGS) $(1) -c -xassembler /dev/null -o "$$TMP",$(1),$(2))
+	$(1) $(KBUILD_CFLAGS) $(2) -c -xassembler /dev/null -o "$$TMP",$(2),$(3))
 
 # as-instr
-# Usage: cflags-y += $(call as-instr,instr,option1,option2)
+# Usage: cflags-y += $(call as-instr, <compiler>, instr, option1, option2)
 
 as-instr = $(call try-run,\
-	/bin/echo -e "$(1)" | $(CC) $(KBUILD_AFLAGS) -c -xassembler -o "$$TMP" -,$(2),$(3))
+	/bin/echo -e "$(2)" | $(1) $(KBUILD_AFLAGS) -c -xassembler -o "$$TMP" -,$(3),$(4))
 
 # cc-option
-# Usage: cflags-y += $(call cc-option,-march=winchip-c6,-march=i586)
+# Usage: cflags-y += $(call cc-option, <compiler>, -march=winchip-c6, -march=i586)
 
 cc-option = $(call try-run,\
-	$(CC) $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) $(1) -c -xc /dev/null -o "$$TMP",$(1),$(2))
+	$(1) $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) $(2) -c -xc /dev/null -o "$$TMP",$(2),$(3))
 
 # cc-option-yn
-# Usage: flag := $(call cc-option-yn,-march=winchip-c6)
+# Usage: flag := $(call cc-option-yn, <compiler>, -march=winchip-c6)
 cc-option-yn = $(call try-run,\
-	$(CC) $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) $(1) -c -xc /dev/null -o "$$TMP",y,n)
+	$(1) $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) $(2) -c -xc /dev/null -o "$$TMP",y,n)
 
 # cc-option-align
 # Prefix align with either -falign or -malign
 cc-option-align = $(subst -functions=0,,\
-	$(call cc-option,-falign-functions=0,-malign-functions=0))
+	$(call cc-option,$(1),-falign-functions=0,-malign-functions=0))
 
 # cc-version
 # Usage gcc-ver := $(call cc-version)
@@ -142,14 +142,14 @@ cc-fullversion = $(shell $(CONFIG_SHELL) \
 cc-ifversion = $(shell [ $(call cc-version, $(CC)) $(1) $(2) ] && echo $(3))
 
 # cc-ldoption
-# Usage: ldflags += $(call cc-ldoption, -Wl$(comma)--hash-style=both)
+# Usage: ldflags += $(call cc-ldoption, <compiler>, -Wl$(comma)--hash-style=both)
 cc-ldoption = $(call try-run,\
-	$(CC) $(1) -nostdlib -xc /dev/null -o "$$TMP",$(1),$(2))
+	$(1) $(2) -nostdlib -xc /dev/null -o "$$TMP",$(2),$(3))
 
 # ld-option
-# Usage: LDFLAGS += $(call ld-option, -X)
+# Usage: LDFLAGS += $(call ld-option, <compiler>, -X)
 ld-option = $(call try-run,\
-	$(CC) /dev/null -c -o "$$TMPO" ; $(LD) $(1) "$$TMPO" -o "$$TMP",$(1),$(2))
+	$(1) /dev/null -c -o "$$TMPO" ; $(LD) $(2) "$$TMPO" -o "$$TMP",$(2),$(3))
 
 ######
 


### PR DESCRIPTION
The Kbuild function cc-option, that is used to test if a certain compiler
flag is supported by the compiler, was called with the wrong compiler if
the variable CONFIG_KERNEL_COMPILER was set to anything else but gcc. The
CC variable used by cc-option was set using CONFIG_KERNEL_COMPILER after
all calls to cc-option, as-option, ld-option, etc had been done. So these
commands always executed with the default gcc compiler and not the configured
one.

Using the cc-option is only sensible when an option may not be supported
by all compilers, so assigning the result of _one_ cc-option call to a variable
that is used by both the kernel and user space is incorrect. The kernel and
user space can be compiled using different compilers by setting the variables
CONFIG_(KERNEL|USER)_COMPILER, so calling cc-option with one of these compilers
and then also assigning the result to the other compiler's options, may lead to
that compiler not understanding the option.

This is quite a big change in the build system, but in order to be able to use one compiler for the kernel and one for user space it seems necessary to do it.

Running the sel4test on these four configurations pass.

sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ cat simulate.sh 
#!/bin/sh
make mrproper ; make x64_simulation_debug_xml_defconfig ; make
make simulate-x86_64
make mrproper ; make ia32_simulation_debug_xml_defconfig ; make
make simulate-ia32
make mrproper ; make kzm_simulation_release_xml_defconfig ; make
make simulate-kzm
make mrproper ; make zynq_simulation_release_xml_defconfig ; make
make simulate-zynq

If build where deterministic it would have been a lot easier to test this patch, but they are not unfortunately (https://github.com/seL4/sel4test/issues/8).

To test that I haven't broken anything I have run make compile-all with a patched compile-all.sh script (see repo diff below) that builds the whole sel4test and saves the logs. I did one compile-all without the patch and one with it. All targets passed compilation. If the build logs are the same for all defconfigs, excluding white-space differences, I assume that nothing is broken, at least not in the sel4test repo. In order to get all the logs (also from the recursive make calls) from the build I had to intercept all invocations of make and add --debug=v V=2 (see make script below that calls a copy of itself adding the parameters). WARNING: Other gits that use cc-option, etc, but that is not included in sel4test will be broken if using the cc-option, and need to add the compiler parameter.

sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ cat /usr/bin/make
#!/bin/sh
make-my-copy --debug=v V=2 $@

All the build logs for all defconfigs where the same except for the ia32 and x64 ones. Examining the differences in the build logs for ia32 and x64 shows that it is only the order of the compiler switches that differ. To prove that (at least to myself) I wrote a script that sorted each line and compared the result. With that definition of equality also the ia32 and x64 build logs matched. See the output of the compare-diffs.sh script just below.

sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ cat compare-diffs.sh 
#!/bin/sh
compare_files () {
    left=$1
    right=$2

    # extract the difference between two logs
    diff -w $left $right > diff.txt

    # compare the differences, and check that each line is equal when sorted
    diff \
        <(grep "^<" diff.txt | sed 's/^..//g' |
          while read line; do echo $line | sed 's/ /\n/g' | sort | awk '{line=line " " $0} END {print line}' ; done) \
        <(grep "^>" diff.txt | sed 's/^..//g' |
          while read line; do echo $line | sed 's/ /\n/g' | sort | awk '{line=line " " $0} END {print line}' ; done)
}

folder1=$1
folder2=$2

# find all defconfigs where the build log is not exactly the same except for white-space differences
defconfigs=$(diff -qwr $folder1 $folder2 | awk '{print $2'} | sed 's/.*\///g')

for i in $defconfigs ; do
    echo "comparing logs for defconfigs $i"
    compare_files $folder1/$i $folder2/$i
done
sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ . compare-diffs.sh buildlogs/220703/ buildlogs/232551/
comparing logs for defconfigs ia32_debug_xml_defconfig.log
comparing logs for defconfigs ia32_release_xml_defconfig.log
comparing logs for defconfigs ia32_release_xml_pae_defconfig.log
comparing logs for defconfigs ia32_simulation_debug_xml_defconfig.log
comparing logs for defconfigs ia32_simulation_release_xml_defconfig.log
comparing logs for defconfigs ia32_simulation_verification_xml_defconfig.log
comparing logs for defconfigs ia32_smp_debug_xml_defconfig.log
comparing logs for defconfigs ia32_smp_release_xml_defconfig.log
comparing logs for defconfigs ia32_smp_verification_xml_defconfig.log
comparing logs for defconfigs ia32_verification_xml_defconfig.log
comparing logs for defconfigs ia32_verification_xml_pae_defconfig.log
comparing logs for defconfigs x64_debug_xml_defconfig.log
comparing logs for defconfigs x64_release_xml_defconfig.log
comparing logs for defconfigs x64_simulation_debug_xml_defconfig.log
comparing logs for defconfigs x64_simulation_release_xml_defconfig.log
comparing logs for defconfigs x64_simulation_verification_xml_defconfig.log
comparing logs for defconfigs x64_smp_debug_xml_defconfig.log
comparing logs for defconfigs x64_smp_release_xml_defconfig.log
comparing logs for defconfigs x64_smp_verification_xml_defconfig.log
comparing logs for defconfigs x64_verification_xml_defconfig.log

sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ repo diff
project projects/sel4test/
diff --git a/tools/compile-all.sh b/tools/compile-all.sh
index ba7d4ca..1113efe 100755
--- a/tools/compile-all.sh
+++ b/tools/compile-all.sh
@@ -12,13 +12,16 @@
 
 exit_code=0
 
+folder=buildlogs/$(date +%H%M%S)
+mkdir -p $folder
+
 for config in `/bin/ls -H -I "bamboo*" configs`
 do
     echo $config
     make clean > /dev/null
     make $config > /dev/null
     make silentoldconfig > /dev/null
-    env -i PATH="$PATH" make kernel_elf > /dev/null
+    env -i PATH="$PATH" make > $folder/$config.log
     if [ $? -eq 0 ]
     then
         echo "pass"

I also wanted to make sure that I haven't forgotten to edit the cc-option in any places, so I ran a script to try to find such places. The search shows mostly comments, and in the other lines I haven't found any forgotten places.

sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ cat find-forgotten-cc-options.sh 
#!/bin/sh
# exclude build and git directories
EXCL="--exclude-dir=build --exclude-dir=stage --exclude-dir=.git"
# check that all calls to the option functions have gotten the compiler added
grep -r cc-option * ${EXCL}   | grep -v "\$(NK_CC)" | grep -v "\$(K_CC)"
grep -r cc-ldoption * ${EXCL} | grep -v "\$(NK_CC)" | grep -v "\$(K_CC)"
grep -r ld-option * ${EXCL}   | grep -v "\$(NK_CC)" | grep -v "\$(K_CC)"
grep -r as-option * ${EXCL}   | grep -v "\$(NK_CC)" | grep -v "\$(K_CC)"
grep -r as-instr * ${EXCL}    | grep -v "\$(NK_CC)" | grep -v "\$(K_CC)"
# find lines with more than one option call
grep -r "\$(call\ .*\$(call\ " * ${EXCL}
sel4@sel4:~/Repo/seL4/TestSuite/sel4test3$ . find-forgotten-cc-options.sh 
common-tool/project.mk:# Kernel cc-option compiler
common-tool/project.mk:# Non-kernel cc-option compiler
kbuild-tool/Kbuild.include:# cc-option
kbuild-tool/Kbuild.include:# Usage: cflags-y += $(call cc-option, <compiler>, -march=winchip-c6, -march=i586)
kbuild-tool/Kbuild.include:cc-option = $(call try-run,\
kbuild-tool/Kbuild.include:# cc-option-yn
kbuild-tool/Kbuild.include:# Usage: flag := $(call cc-option-yn, <compiler>, -march=winchip-c6)
kbuild-tool/Kbuild.include:cc-option-yn = $(call try-run,\
kbuild-tool/Kbuild.include:# cc-option-align
kbuild-tool/Kbuild.include:cc-option-align = $(subst -functions=0,,\
kbuild-tool/Kbuild.include:	$(call cc-option,$(1),-falign-functions=0,-malign-functions=0))
projects/tools/common-tool/project.mk:# Kernel cc-option compiler
projects/tools/common-tool/project.mk:# Non-kernel cc-option compiler
projects/tools/kbuild-tool/Kbuild.include:# cc-option
projects/tools/kbuild-tool/Kbuild.include:# Usage: cflags-y += $(call cc-option, <compiler>, -march=winchip-c6, -march=i586)
projects/tools/kbuild-tool/Kbuild.include:cc-option = $(call try-run,\
projects/tools/kbuild-tool/Kbuild.include:# cc-option-yn
projects/tools/kbuild-tool/Kbuild.include:# Usage: flag := $(call cc-option-yn, <compiler>, -march=winchip-c6)
projects/tools/kbuild-tool/Kbuild.include:cc-option-yn = $(call try-run,\
projects/tools/kbuild-tool/Kbuild.include:# cc-option-align
projects/tools/kbuild-tool/Kbuild.include:cc-option-align = $(subst -functions=0,,\
projects/tools/kbuild-tool/Kbuild.include:	$(call cc-option,$(1),-falign-functions=0,-malign-functions=0))
kbuild-tool/Kbuild.include:# cc-ldoption
kbuild-tool/Kbuild.include:# Usage: ldflags += $(call cc-ldoption, <compiler>, -Wl$(comma)--hash-style=both)
kbuild-tool/Kbuild.include:cc-ldoption = $(call try-run,\
projects/tools/kbuild-tool/Kbuild.include:# cc-ldoption
projects/tools/kbuild-tool/Kbuild.include:# Usage: ldflags += $(call cc-ldoption, <compiler>, -Wl$(comma)--hash-style=both)
projects/tools/kbuild-tool/Kbuild.include:cc-ldoption = $(call try-run,\
kbuild-tool/Kbuild.include:# ld-option
kbuild-tool/Kbuild.include:# Usage: LDFLAGS += $(call ld-option, <compiler>, -X)
kbuild-tool/Kbuild.include:ld-option = $(call try-run,\
projects/tools/kbuild-tool/Kbuild.include:# ld-option
projects/tools/kbuild-tool/Kbuild.include:# Usage: LDFLAGS += $(call ld-option, <compiler>, -X)
projects/tools/kbuild-tool/Kbuild.include:ld-option = $(call try-run,\
kbuild-tool/Kbuild.include:# as-option
kbuild-tool/Kbuild.include:# Usage: cflags-y += $(call as-option, <compiler>, -Wa$(comma)-isa=foo,)
kbuild-tool/Kbuild.include:as-option = $(call try-run,\
projects/tools/kbuild-tool/Kbuild.include:# as-option
projects/tools/kbuild-tool/Kbuild.include:# Usage: cflags-y += $(call as-option, <compiler>, -Wa$(comma)-isa=foo,)
projects/tools/kbuild-tool/Kbuild.include:as-option = $(call try-run,\
kbuild-tool/Kbuild.include:# as-instr
kbuild-tool/Kbuild.include:# Usage: cflags-y += $(call as-instr, <compiler>, instr, option1, option2)
kbuild-tool/Kbuild.include:as-instr = $(call try-run,\
projects/tools/kbuild-tool/Kbuild.include:# as-instr
projects/tools/kbuild-tool/Kbuild.include:# Usage: cflags-y += $(call as-instr, <compiler>, instr, option1, option2)
projects/tools/kbuild-tool/Kbuild.include:as-instr = $(call try-run,\
common-tool/Makefile.flags:	NK_CCFLAGS += $(call cc-option,$(NK_CC),-g3,-g) $(call cc-option,$(NK_CC),-ggdb3,-ggdb) $(call cc-option,$(NK_CC),-save-temps,)
projects/tools/common-tool/Makefile.flags:	NK_CCFLAGS += $(call cc-option,$(NK_CC),-g3,-g) $(call cc-option,$(NK_CC),-ggdb3,-ggdb) $(call cc-option,$(NK_CC),-save-temps,)
projects/tools/kbuild-tool/Makefile.lib:__c_flags	= $(call addtree,-I$(obj)) $(call flags,_c_flags)
