### PR TITLE
Secure Load & IBLL

### DIFF
--- a/common-tool/common.mk
+++ b/common-tool/common.mk
@@ -204,6 +204,7 @@ default: $(PRIORITY_TARGETS) install-headers $(TARGETS)
 #
 default: $(patsubst %.bin,$(SEL4_BINDIR)/%,$(filter %.bin,$(TARGETS)))
 default: $(patsubst %.a,$(SEL4_LIBDIR)/%.a,$(filter %.a,$(TARGETS)))
+#default: $(patsubst %.a,$(EXTLIBDIRS)/%.a,$(filter %.a,$(TARGETS)))
 
 $(SEL4_BINDIR)/%: %.bin
 	$(Q)mkdir -p $(dir $@)

--- a/common-tool/project-arm.mk
+++ b/common-tool/project-arm.mk
@@ -39,6 +39,7 @@ elfloader: libcpio common FORCE
 %-image: export TOOLPREFIX=$(CONFIG_CROSS_COMPILER_PREFIX:"%"=%)
 %-image: export STRIP=$(CONFIG_REMOVE_SYMBOLS)
 %-image: export HASH=$(CONFIG_HASH_INSTRUCTIONS)
+%-image: export HASH_SHA=$(CONFIG_HASH_SHA)
 %-image: export V
 %-image: % kernel_elf common elfloader FORCE
 	@echo "[GEN_IMAGE] $@-$(ARCH)-$(PLAT)"

--- a/common-tool/project-arm.mk
+++ b/common-tool/project-arm.mk
@@ -37,11 +37,26 @@ elfloader: libcpio common FORCE
 	@echo "[elfloader] done."
 
 %-image: export TOOLPREFIX=$(CONFIG_CROSS_COMPILER_PREFIX:"%"=%)
+%-image: export STRIP=$(CONFIG_REMOVE_SYMBOLS)
+%-image: export HASH=$(CONFIG_HASH_INSTRUCTIONS)
 %-image: export V
 %-image: % kernel_elf common elfloader FORCE
 	@echo "[GEN_IMAGE] $@-$(ARCH)-$(PLAT)"
 	$(Q)$(SEL4_COMMON)/elfloader/gen_boot_image.sh $(STAGE_BASE)/kernel.elf \
 		$(STAGE_BASE)/bin/$< $(IMAGE_ROOT)/$@-$(ARCH)-$(PLAT) 2>&1 \
+		| while read line; do echo " [GEN_IMAGE] $$line"; done; \
+		exit $${PIPESTATUS[0]}
+
+# make pre-image IMAGE_DIR=~/sel4-tutorials/stage/arm/zynq7000/bin/hello-3
+pre-image: export TOOLPREFIX=$(CONFIG_CROSS_COMPILER_PREFIX:"%"=%)
+pre-image: export STRIP=$(CONFIG_REMOVE_SYMBOLS)
+pre-image: export HASH=$(CONFIG_HASH_INSTRUCTIONS)
+pre-image: export HASH_SHA=$(CONFIG_HASH_SHA)
+pre-image: export V
+pre-image: elfloader
+	@echo "[GEN_IMAGE] $(apps)-image-$(ARCH)-$(PLAT)"
+	$(Q)$(SEL4_COMMON)/elfloader/gen_boot_image.sh $(STAGE_BASE)/kernel.elf \
+		$(IMAGE_DIR) $(IMAGE_ROOT)/image 2>&1 \
 		| while read line; do echo " [GEN_IMAGE] $$line"; done; \
 		exit $${PIPESTATUS[0]}
 

--- a/elfloader-tool/Kconfig
+++ b/elfloader-tool/Kconfig
@@ -74,17 +74,24 @@ endchoice
 
 config REMOVE_SYMBOLS
     bool "Remove ELF symbols from the final image"
-    default y 
+    default y
 	depends on IMAGE_ELF
     help
        Remove ELF symbols from the final image.
 
-config HASH_INSTRUCTIONS
-	bool "Perform a MD5 Hash of the .text section of elf file"
+menuconfig HASH_INSTRUCTIONS
+	bool "Perform a SHA256/MD5 Hash of the of each elf file that the elfloader checks on load"
 	default n
 	depends on IMAGE_ELF
 	help
-		Hashes .text, adds in a .md5 section with the hash for each elf file (kernel + application)
+		Hashes each elf file (kernel + application)
+
+        config HASH_SHA
+        bool "Perform an SHA256 Hash on each ELF File. If this option isn't selected, then an MD5 Hash will be performed"
+        depends on HASH_INSTRUCTIONS
+        default y
+        help
+            Perform an SHA256 Hash on each ELF File. If this option isn't selected, then an MD5 Hash will be performed
 
 config ARM_MONITOR_HOOK
     bool "Install hooks in monitor mode"

--- a/elfloader-tool/Kconfig
+++ b/elfloader-tool/Kconfig
@@ -72,6 +72,20 @@ config ARM_HYPERVISOR_MODE
 
 endchoice
 
+config REMOVE_SYMBOLS
+    bool "Remove ELF symbols from the final image"
+    default y 
+	depends on IMAGE_ELF
+    help
+       Remove ELF symbols from the final image.
+
+config HASH_INSTRUCTIONS
+	bool "Perform a MD5 Hash of the .text section of elf file"
+	default n
+	depends on IMAGE_ELF
+	help
+		Hashes .text, adds in a .md5 section with the hash for each elf file (kernel + application)
+
 config ARM_MONITOR_HOOK
     bool "Install hooks in monitor mode"
     default n 

--- a/elfloader-tool/Makefile
+++ b/elfloader-tool/Makefile
@@ -29,6 +29,7 @@ CFILES   += $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/arch-$(ARC
 CFILES   += $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/plat/$(PLAT)/*.c))
 CFILES   += $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/binaries/elf/*.c))
 CFILES   += $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/arch-$(ARCH)/$(TYPE_SUFFIX)/*.c))
+CFILES   += $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/arch-$(ARCH)/utils/*.c))
 CFILES   += $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/arch-$(ARCH)/armv/$(ARMV)/$(TYPE_SUFFIX)/*.c))
 
 ASMFILES := $(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/plat/$(PLAT)/*.S))

--- a/elfloader-tool/Makefile
+++ b/elfloader-tool/Makefile
@@ -51,7 +51,7 @@ endif
 
 LIBS = cpio
 
-NK_CFLAGS += -ffreestanding -Wall -Werror -W -Wextra
+NK_CFLAGS += -ffreestanding -Wall -W -Wextra
 
 include $(SEL4_COMMON)/common.mk
 

--- a/elfloader-tool/include/strops.h
+++ b/elfloader-tool/include/strops.h
@@ -17,7 +17,7 @@
 
 size_t strlen(const char *str);
 int strcmp(const char *a, const char *b);
-int strncmp(const char* s1, const char* s2, int n);
+int strncmp(const char* s1, const char* s2, size_t n);
 void *memset(void *s, int c, size_t n);
 void *memcpy(void *dest, const void *src, size_t n);
 

--- a/elfloader-tool/include/strops.h
+++ b/elfloader-tool/include/strops.h
@@ -15,7 +15,9 @@
 
 #include <types.h>
 
+size_t strlen(const char *str);
 int strcmp(const char *a, const char *b);
+int strncmp(const char* s1, const char* s2, int n);
 void *memset(void *s, int c, size_t n);
 void *memcpy(void *dest, const void *src, size_t n);
 

--- a/elfloader-tool/src/arch-arm/README.txt
+++ b/elfloader-tool/src/arch-arm/README.txt
@@ -1,0 +1,15 @@
+The elfloader Kconfig isn't accessable in most of the top-level Kconfigs.
+Therefore, there are two ways to use the hashing algorithms:
+      1. CONFIG_HASH_INSTRUCTIONS=y in your defconfig
+         CONFIG_HASH_SHA (optional - remove if you want to md5 hash)
+      2. Include the elf-loader's Kconfig under a new menu in your top-level Kconfig
+         like this:
+    
+         menu "Tools"
+           source "tools/elfloader/Kconfig"
+         endmenu
+
+Either one of these options will allow the user to select the hashing process.
+
+Please note, this process will add boottime, as hashing a very long file tends to take some time.
+

--- a/elfloader-tool/src/arch-arm/crypt_md5.h
+++ b/elfloader-tool/src/arch-arm/crypt_md5.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_GPL)
+ *
+ * This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+ * a DARPA SBIR, Contract Number D16PC00107.
+ *
+ * Approved for Public Release, Distribution Unlimited.
+ *
+ */
+
+#ifndef _CRYPT_MD5_H
+#define _CRYPT_MD5_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	uint64_t len;    /* processed message length */
+	uint32_t h[4];   /* hash state */
+	uint8_t buf[64]; /* message block buffer */
+} md5_t;
+
+void md5_init(md5_t *s);
+void md5_sum(md5_t *s, uint8_t *md);
+void md5_update(md5_t *s, const void *m, unsigned long len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/elfloader-tool/src/arch-arm/crypt_sha256.h
+++ b/elfloader-tool/src/arch-arm/crypt_sha256.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_GPL)
+ *
+ * This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+ * a DARPA SBIR, Contract Number D16PC00107.
+ *
+ * Approved for Public Release, Distribution Unlimited.
+ *
+ */
+
+#ifndef _CRYPT_SHA256_H
+#define _CRYPT_SHA256_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	uint64_t len;    /* processed message length */
+	uint32_t h[8];   /* hash state */
+	uint8_t buf[64]; /* message block buffer */
+} sha256_t;
+
+void sha256_init(sha256_t *s);
+void sha256_sum(sha256_t *s, uint8_t *md);
+void sha256_update(sha256_t *s, const void *m, unsigned long len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/elfloader-tool/src/arch-arm/hash.h
+++ b/elfloader-tool/src/arch-arm/hash.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_GPL)
+ *
+ * This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+ * a DARPA SBIR, Contract Number D16PC00107.
+ *
+ * Approved for Public Release, Distribution Unlimited.
+ *
+ */
+
+#ifndef _CRYPT_HASH_H
+#define _CRYPT_HASH_H
+
+#include "crypt_sha256.h"
+#include "crypt_md5.h"
+
+/* enum to store the hashing methods */
+enum hash_methods {
+    SHA_256,
+    MD5
+};
+
+/* Structure that contains a structure for each hash type and an integer representation
+ * of the hashing method used
+ */
+typedef struct {
+    sha256_t sha_structure;
+    md5_t md5_structure;
+    unsigned int hash_type;
+} hashes_t;
+
+void get_hash(hashes_t hashes, const void *file_to_hash, unsigned long bytes_to_hash, uint8_t *outputted_hash);
+void print_hash(uint8_t *hash_to_print, int bytes_to_print);
+
+#endif

--- a/elfloader-tool/src/arch-arm/main.c
+++ b/elfloader-tool/src/arch-arm/main.c
@@ -10,6 +10,8 @@
  * @TAG(DATA61_GPL)
  */
 
+#include <autoconf.h>
+
 #include <printf.h>
 #include <types.h>
 #include <abort.h>
@@ -19,7 +21,15 @@
 
 #include <elfloader.h>
 
-#include "crypt_md5.h"
+#ifdef CONFIG_HASH_INSTRUCTIONS
+  #ifdef CONFIG_HASH_SHA
+    #include "crypt_sha256.h"
+  #else
+    #include "crypt_md5.h"
+  #endif
+#endif
+
+#include "hash.h"
 
 /* Determine if two intervals overlap. */
 static int regions_overlap(uintptr_t startA, uintptr_t endA,
@@ -94,8 +104,8 @@ static void unpack_elf_to_paddr(void *elf, paddr_t dest_paddr)
  *
  * Return the byte past the last byte of the physical address used.
  */
-static paddr_t load_elf(const char *name, void *elf,
-                        paddr_t dest_paddr, struct image_info *info, int keep_headers)
+static paddr_t load_elf(const char *name, void *elf, paddr_t dest_paddr,
+                        struct image_info *info, int keep_headers, unsigned long size, const char *hash)
 {
     uint64_t min_vaddr, max_vaddr;
     size_t image_size;
@@ -118,48 +128,51 @@ static paddr_t load_elf(const char *name, void *elf,
         abort();
     }
 
-	char * secname = ".text";
-	char * secbuf;
-	unsigned seclen, j;
-	char found = 0;
+#ifdef CONFIG_HASH_INSTRUCTIONS
 
-	for(j=0; j<elf_getNumSections(elf);j++)	{
-		if(!strcmp(elf_getSectionName(elf,j),secname))	break; //the section is named .data, break the loop
-	}
-	secbuf = elf_getSection(elf,j);
-	seclen = elf_getSectionSize(elf, j);
+    /* Get the binary file that contains the SHA256 Hash */
+    unsigned long unused;
+    void *file_hash = cpio_get_file(_archive_start, (const char *)hash, &unused);
+    uint8_t *print_hash_pointer = (uint8_t *)file_hash;
 
-	unsigned char md[16];
-	md5_t md5;
-	md5_init(&md5);
+    /* If the file hash doesn't have a pointer, the file doesn't exist, so we cannot confirm the file is what we expect. Abort */
+    if(file_hash == NULL) {
+        printf("Cannot compare hashes for %s, expected hash, %s, doesn't exist\n", name, hash);
+        abort();
+    }
+    else {
 
-	md5_update(&md5, secbuf, seclen);
-	md5_sum(&md5, md);
+        hashes_t hashes;
 
-	printf("Hash for .text section: ");
-	for(int i =0; i < 16; i++) printf("%02x",md[i]);
-	printf("\n");
+#ifdef CONFIG_HASH_SHA
+        int hash_len = 32;
+        hashes.hash_type = SHA_256;
+#else
+        int hash_len = 16;
+        hashes.hash_type = MD5;
+#endif
 
-	secname = ".md5";
-	for(j=0, found=0; j<elf_getNumSections(elf); j++)	{
-		if(!strcmp(elf_getSectionName(elf,j),secname))	{
-			found = 1;
-			break; //the section is named .md5, break the loop
-		}
-	}
-	if(found)	{
-		secbuf = elf_getSection(elf,j);
-		seclen = elf_getSectionSize(elf, j);
+        uint8_t calculated_hash[hash_len];
 
-		printf("Received Hash from ELF: ");
-		for(unsigned i = 0; i < seclen; i++) printf("%02x",secbuf[i]);
-		printf("\n");
+        /* Print the Hash for the user to see */
+        printf("Hash from ELF File: ");
+        print_hash(print_hash_pointer, hash_len);
 
-		if(strncmp(secbuf,(char *)md,16) != 0) {
-			printf("Hashes are different. Load failure\n");
-			abort();
-		}
-	}
+        get_hash(hashes, elf, size, calculated_hash);
+
+        /* Print the hash so the user can see they're the same or different */
+        printf("Hash for ELF Input: ");
+        print_hash(calculated_hash, hash_len);
+
+        /* Check to make sure the hashes are the same */
+        if(strncmp((char *)file_hash, (char *)calculated_hash, hash_len) != 0) {
+            printf("Hashes are different. Load failure\n");
+            abort();
+        }
+    }
+
+#endif  /* CONFIG_HASH_INSTRUCTIONS */
+
     /* Print diagnostics. */
     printf("ELF-loading image '%s'\n", name);
     printf("  paddr=[%lx..%lx]\n", dest_paddr, dest_paddr + image_size - 1);
@@ -270,7 +283,7 @@ void load_images(struct image_info *kernel_info, struct image_info *user_info,
 
     elf_getMemoryBounds(kernel_elf, 1, &kernel_phys_start, &kernel_phys_end);
     next_phys_addr = load_elf("kernel", kernel_elf,
-                              (paddr_t)kernel_phys_start, kernel_info, 0);
+                              (paddr_t)kernel_phys_start, kernel_info, 0, unused, "kernel.bin");
 
     /*
      * Load userspace images.
@@ -294,7 +307,7 @@ void load_images(struct image_info *kernel_info, struct image_info *user_info,
 
         /* Load the file into memory. */
         next_phys_addr = load_elf(elf_filename, user_elf,
-                                  next_phys_addr, &user_info[*num_images], 1);
+                                  next_phys_addr, &user_info[*num_images], 1, unused, "app.bin");
         *num_images = i + 1;
     }
 }

--- a/elfloader-tool/src/arch-arm/utils/crypt_md5.c
+++ b/elfloader-tool/src/arch-arm/utils/crypt_md5.c
@@ -1,0 +1,164 @@
+/*
+* Copyright 2017, DornerWorks
+*
+* This software may be distributed and modified according to the terms of
+* the GNU General Public License version 2. Note that NO WARRANTY is provided.
+* See "LICENSE_GPLv2.txt" for details.
+*
+* @TAG(DORNERWORKS_GPL)
+*
+* This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+* a DARPA SBIR, Contract Number D16PC00107.
+*
+* Approved for Public Release, Distribution Unlimited.
+*
+*/
+
+/*
+ * md5 crypt implementation
+ *
+ * original md5 crypt design is from Poul-Henning Kamp
+ * this implementation was created based on the code in freebsd
+ * at least 32bit int is assumed, key is limited and $1$ prefix is mandatory,
+ * on error "*" is returned
+ */
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "../crypt_md5.h"
+
+/* public domain md5 implementation based on rfc1321 and libtomcrypt */
+
+static uint32_t rol(uint32_t n, int k) { return (n << k) | (n >> (32-k)); }
+#define F(x,y,z) (z ^ (x & (y ^ z)))
+#define G(x,y,z) (y ^ (z & (y ^ x)))
+#define H(x,y,z) (x ^ y ^ z)
+#define I(x,y,z) (y ^ (x | ~z))
+#define FF(a,b,c,d,w,s,t) a += F(b,c,d) + w + t; a = rol(a,s) + b
+#define GG(a,b,c,d,w,s,t) a += G(b,c,d) + w + t; a = rol(a,s) + b
+#define HH(a,b,c,d,w,s,t) a += H(b,c,d) + w + t; a = rol(a,s) + b
+#define II(a,b,c,d,w,s,t) a += I(b,c,d) + w + t; a = rol(a,s) + b
+
+static const uint32_t tab[64] = {
+0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391
+};
+
+static void processblock(md5_t *s, const uint8_t *buf)
+{
+	uint32_t i, W[16], a, b, c, d;
+
+	for (i = 0; i < 16; i++) {
+		W[i] = buf[4*i];
+		W[i] |= (uint32_t)buf[4*i+1]<<8;
+		W[i] |= (uint32_t)buf[4*i+2]<<16;
+		W[i] |= (uint32_t)buf[4*i+3]<<24;
+	}
+
+	a = s->h[0];
+	b = s->h[1];
+	c = s->h[2];
+	d = s->h[3];
+
+	i = 0;
+	while (i < 16) {
+		FF(a,b,c,d, W[i],  7, tab[i]); i++;
+		FF(d,a,b,c, W[i], 12, tab[i]); i++;
+		FF(c,d,a,b, W[i], 17, tab[i]); i++;
+		FF(b,c,d,a, W[i], 22, tab[i]); i++;
+	}
+	while (i < 32) {
+		GG(a,b,c,d, W[(5*i+1)%16],  5, tab[i]); i++;
+		GG(d,a,b,c, W[(5*i+1)%16],  9, tab[i]); i++;
+		GG(c,d,a,b, W[(5*i+1)%16], 14, tab[i]); i++;
+		GG(b,c,d,a, W[(5*i+1)%16], 20, tab[i]); i++;
+	}
+	while (i < 48) {
+		HH(a,b,c,d, W[(3*i+5)%16],  4, tab[i]); i++;
+		HH(d,a,b,c, W[(3*i+5)%16], 11, tab[i]); i++;
+		HH(c,d,a,b, W[(3*i+5)%16], 16, tab[i]); i++;
+		HH(b,c,d,a, W[(3*i+5)%16], 23, tab[i]); i++;
+	}
+	while (i < 64) {
+		II(a,b,c,d, W[7*i%16],  6, tab[i]); i++;
+		II(d,a,b,c, W[7*i%16], 10, tab[i]); i++;
+		II(c,d,a,b, W[7*i%16], 15, tab[i]); i++;
+		II(b,c,d,a, W[7*i%16], 21, tab[i]); i++;
+	}
+
+	s->h[0] += a;
+	s->h[1] += b;
+	s->h[2] += c;
+	s->h[3] += d;
+}
+
+static void pad(md5_t *s)
+{
+	unsigned r = s->len % 64;
+
+	s->buf[r++] = 0x80;
+	if (r > 56) {
+		memset(s->buf + r, 0, 64 - r);
+		r = 0;
+		processblock(s, s->buf);
+	}
+	memset(s->buf + r, 0, 56 - r);
+	s->len *= 8;
+	s->buf[56] = s->len;
+	s->buf[57] = s->len >> 8;
+	s->buf[58] = s->len >> 16;
+	s->buf[59] = s->len >> 24;
+	s->buf[60] = s->len >> 32;
+	s->buf[61] = s->len >> 40;
+	s->buf[62] = s->len >> 48;
+	s->buf[63] = s->len >> 56;
+	processblock(s, s->buf);
+}
+
+void md5_init(md5_t *s)
+{
+	s->len = 0;
+	s->h[0] = 0x67452301;
+	s->h[1] = 0xefcdab89;
+	s->h[2] = 0x98badcfe;
+	s->h[3] = 0x10325476;
+}
+
+void md5_sum(md5_t *s, uint8_t *md)
+{
+	int i;
+
+	pad(s);
+	for (i = 0; i < 4; i++) {
+		md[4*i] = s->h[i];
+		md[4*i+1] = s->h[i] >> 8;
+		md[4*i+2] = s->h[i] >> 16;
+		md[4*i+3] = s->h[i] >> 24;
+	}
+}
+
+void md5_update(md5_t *s, const void *m, unsigned long len)
+{
+	const uint8_t *p = m;
+	unsigned r = s->len % 64;
+	s->len += len;
+	if (r) {
+		if (len < 64 - r) {
+			memcpy(s->buf + r, p, len);
+			return;
+		}
+		memcpy(s->buf + r, p, 64 - r);
+		len -= 64 - r;
+		p += 64 - r;
+		processblock(s, s->buf);
+	}
+	for (; len >= 64; len -= 64, p += 64)
+		processblock(s, p);
+	memcpy(s->buf, p, len);
+}

--- a/elfloader-tool/src/arch-arm/utils/crypt_sha256.c
+++ b/elfloader-tool/src/arch-arm/utils/crypt_sha256.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_GPL)
+ *
+ * This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+ * a DARPA SBIR, Contract Number D16PC00107.
+ *
+ * Approved for Public Release, Distribution Unlimited.
+ *
+ */
+
+/*
+ * public domain sha256 crypt implementation
+ *
+ * original sha crypt design: http://people.redhat.com/drepper/SHA-crypt.txt
+ * in this implementation at least 32bit int is assumed,
+ * key length is limited, the $5$ prefix is mandatory, '\n' and ':' is rejected
+ * in the salt and rounds= setting must contain a valid iteration count,
+ * on error "*" is returned.
+ */
+#include <ctype.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../crypt_sha256.h"
+
+#define KEY_MAX 256
+#define SALT_MAX 16
+#define ROUNDS_DEFAULT 5000
+#define ROUNDS_MIN 1000
+#define ROUNDS_MAX 9999999
+
+/* public domain sha256 implementation based on fips180-3 */
+
+static uint32_t ror(uint32_t n, int k) { return (n >> k) | (n << (32-k)); }
+#define Ch(x,y,z)  (z ^ (x & (y ^ z)))
+#define Maj(x,y,z) ((x & y) | (z & (x | y)))
+#define S0(x)      (ror(x,2) ^ ror(x,13) ^ ror(x,22))
+#define S1(x)      (ror(x,6) ^ ror(x,11) ^ ror(x,25))
+#define R0(x)      (ror(x,7) ^ ror(x,18) ^ (x>>3))
+#define R1(x)      (ror(x,17) ^ ror(x,19) ^ (x>>10))
+
+static const uint32_t K[64] = {
+0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+static void processblock(sha256_t *s, const uint8_t *buf)
+{
+	uint32_t W[64], t1, t2, a, b, c, d, e, f, g, h;
+	int i;
+
+	for (i = 0; i < 16; i++) {
+		W[i] = (uint32_t)buf[4*i]<<24;
+		W[i] |= (uint32_t)buf[4*i+1]<<16;
+		W[i] |= (uint32_t)buf[4*i+2]<<8;
+		W[i] |= buf[4*i+3];
+	}
+	for (; i < 64; i++)
+		W[i] = R1(W[i-2]) + W[i-7] + R0(W[i-15]) + W[i-16];
+	a = s->h[0];
+	b = s->h[1];
+	c = s->h[2];
+	d = s->h[3];
+	e = s->h[4];
+	f = s->h[5];
+	g = s->h[6];
+	h = s->h[7];
+	for (i = 0; i < 64; i++) {
+		t1 = h + S1(e) + Ch(e,f,g) + K[i] + W[i];
+		t2 = S0(a) + Maj(a,b,c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + t1;
+		d = c;
+		c = b;
+		b = a;
+		a = t1 + t2;
+	}
+	s->h[0] += a;
+	s->h[1] += b;
+	s->h[2] += c;
+	s->h[3] += d;
+	s->h[4] += e;
+	s->h[5] += f;
+	s->h[6] += g;
+	s->h[7] += h;
+}
+
+static void pad(sha256_t *s)
+{
+	unsigned r = s->len % 64;
+
+	s->buf[r++] = 0x80;
+	if (r > 56) {
+		memset(s->buf + r, 0, 64 - r);
+		r = 0;
+		processblock(s, s->buf);
+	}
+	memset(s->buf + r, 0, 56 - r);
+	s->len *= 8;
+	s->buf[56] = s->len >> 56;
+	s->buf[57] = s->len >> 48;
+	s->buf[58] = s->len >> 40;
+	s->buf[59] = s->len >> 32;
+	s->buf[60] = s->len >> 24;
+	s->buf[61] = s->len >> 16;
+	s->buf[62] = s->len >> 8;
+	s->buf[63] = s->len;
+	processblock(s, s->buf);
+}
+
+void sha256_init(sha256_t *s)
+{
+	s->len = 0;
+	s->h[0] = 0x6a09e667;
+	s->h[1] = 0xbb67ae85;
+	s->h[2] = 0x3c6ef372;
+	s->h[3] = 0xa54ff53a;
+	s->h[4] = 0x510e527f;
+	s->h[5] = 0x9b05688c;
+	s->h[6] = 0x1f83d9ab;
+	s->h[7] = 0x5be0cd19;
+}
+
+void sha256_sum(sha256_t *s, uint8_t *md)
+{
+	int i;
+
+	pad(s);
+	for (i = 0; i < 8; i++) {
+		md[4*i] = s->h[i] >> 24;
+		md[4*i+1] = s->h[i] >> 16;
+		md[4*i+2] = s->h[i] >> 8;
+		md[4*i+3] = s->h[i];
+	}
+}
+
+void sha256_update(sha256_t *s, const void *m, unsigned long len)
+{
+	const uint8_t *p = m;
+	unsigned r = s->len % 64;
+
+	s->len += len;
+	if (r) {
+		if (len < 64 - r) {
+			memcpy(s->buf + r, p, len);
+			return;
+		}
+		memcpy(s->buf + r, p, 64 - r);
+		len -= 64 - r;
+		p += 64 - r;
+		processblock(s, s->buf);
+	}
+	for (; len >= 64; len -= 64, p += 64)
+		processblock(s, p);
+	memcpy(s->buf, p, len);
+}

--- a/elfloader-tool/src/arch-arm/utils/hash.c
+++ b/elfloader-tool/src/arch-arm/utils/hash.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_GPL)
+ *
+ * This data was produced by DornerWorks, Ltd. of Grand Rapids, MI, USA under
+ * a DARPA SBIR, Contract Number D16PC00107.
+ *
+ * Approved for Public Release, Distribution Unlimited.
+ *
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "../hash.h"
+
+/* Function to perform all hash operations.
+ *
+ * The outputted hash is stored in the outputted_hash pointer after the "sum" operation is used.
+ *
+ * This way beats having a bunch of #ifdefs in the source code, and is scalable to any other
+ * hashing algoritm
+ */
+void get_hash(hashes_t hashes, const void *file_to_hash, unsigned long bytes_to_hash, uint8_t *outputted_hash)
+{
+    if (hashes.hash_type == SHA_256) {
+        sha256_t calculated_hash = hashes.sha_structure;
+        sha256_init(&calculated_hash);
+        sha256_update(&calculated_hash, file_to_hash, bytes_to_hash);
+        sha256_sum(&calculated_hash, outputted_hash);
+    }
+    else {
+        md5_t calculated_hash = hashes.md5_structure;
+        md5_init(&calculated_hash);
+        md5_update(&calculated_hash, file_to_hash, bytes_to_hash);
+        md5_sum(&calculated_hash, outputted_hash);
+    }
+}
+
+/* Function to print the hash */
+void print_hash(uint8_t *hash_to_print, int bytes_to_print)
+{
+    for(int i = 0; i < bytes_to_print; i++) {
+        printf("%02x",*hash_to_print++);
+    }
+    printf("\n");
+}

--- a/elfloader-tool/src/string.c
+++ b/elfloader-tool/src/string.c
@@ -27,6 +27,14 @@
 typedef word_t __attribute__((__may_alias__)) u_alias;
 #endif
 
+size_t strlen(const char *str)
+{
+	const char *s;
+	for (s = str; *s; ++s);
+	return (s - str);
+}
+
+
 int strcmp(const char *a, const char *b)
 {
     while (1) {
@@ -39,6 +47,21 @@ int strcmp(const char *a, const char *b)
         a++;
         b++;
     }
+}
+
+int strncmp(const char* s1, const char* s2, int n)
+{
+    word_t i;
+    int diff;
+
+    for (i = 0; i < n; i++) {
+        diff = ((unsigned char*)s1)[i] - ((unsigned char*)s2)[i];
+        if (diff != 0 || s1[i] == '\0') {
+            return diff;
+        }
+    }
+
+    return 0;
 }
 
 void *memset(void *s, int c, size_t n)
@@ -99,4 +122,3 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n)
 
     return dest;
 }
-

--- a/elfloader-tool/src/string.c
+++ b/elfloader-tool/src/string.c
@@ -49,7 +49,7 @@ int strcmp(const char *a, const char *b)
     }
 }
 
-int strncmp(const char* s1, const char* s2, int n)
+int strncmp(const char* s1, const char* s2, size_t n)
 {
     word_t i;
     int diff;


### PR DESCRIPTION
Secure Load is a way to ensure that what was built by the developer is not tampered with before loading onto the target platform.

In the original build process, the Kernel and the Application are stored into an archive for the elfloader to unpack. This process performs an md5 or a sha256 sum on both of the files and stores the resulting checksum in the archive with the images. The elfloader was modified to perform the same sum on the images, and compare the calculated sum and the sum in the archive. The sum is also printed out during the build process and during loading, so even if someone changed the executable's bits and the sum image in the archive, the difference could be noticed by the developer by a simple eye test.

Because the elfloader Kconfig isn't accessable in most of the top-level Kconfigs, there are two ways to invoke the hashing algorithms:
      1. CONFIG_HASH_INSTRUCTIONS=y in your defconfig
         CONFIG_HASH_SHA (optional - remove if you want to md5 hash)
      2. Include the elf-loader's Kconfig under a new menu in your top-level Kconfig
         like this:
         menu "Tools"
           source "tools/elfloader/Kconfig"
         endmenu

The makefile was modified to ensure the proper variables were exported when the gen_boot_image.sh script is run. 

A pre-image command was also added which allows the user to link a pre-built application image for an seL4 application (not CAmkES). This allows developers to collaborate without sharing source code and intellectual property. 

This entire process is called Independent Build, Link, and Load (IBLL), since the Kernel, Libraries, and Applications are all built separately and can be built at different times and by different developers, then linked and reliably loaded onto the targets.