### PR TITLE
Make library builds deterministic by passing D to ar utility

### DIFF
--- a/common-tool/common.mk
+++ b/common-tool/common.mk
@@ -289,7 +289,7 @@ endif
 %.a: $(OBJFILES)
 	@echo " [AR] $@ objs:$(OBJFILES)"
 	$(Q)mkdir -p $(dir $@)
-	$(Q)$(AR) r $@ $(OBJFILES) > /dev/null 2>&1
+	$(Q)$(AR) Dr $@ $(OBJFILES) > /dev/null 2>&1
 
 %.bin: %.elf
 	$(call cp_file,$<,$@)


### PR DESCRIPTION
If binutils was configured with --enable-deterministic-archives, the D
option is enabled by default, which it is for Ubuntu. For Fedora it is
not enabled by default, so ar invokations with the same parameters
results in different binaries.

Machine and script:
```
[seL4test]$ cat /proc/cpuinfo | grep "processor"
processor	: 0
processor	: 1
processor	: 2
processor	: 3
[seL4test]$ uname -rom
4.15.3-300.fc27.x86_64 x86_64 GNU/Linux
[seL4test]$ ar --version
GNU ar version 2.29-6.fc27
Copyright (C) 2017 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) any later version.
This program has absolutely no warranty.
[seL4test]$ cat reproducible.sh 
#!/bin/sh

THREADS=$1
CONFIG=$2
TARGET=$3
BIN=$4

for i in {1..10} ; do
    make mrproper > /dev/null 2>&1
    make ${CONFIG} > /dev/null 2>&1
    make -j ${THREADS} ${TARGET} > /dev/null 2>&1
    sha1sum ${BIN}
done
```

Running the reproducible script on libsel4 without the patch on Fedora gives different sha's:
```
[seL4test]$ . reproducible.sh 1 x64_simulation_debug_xml_defconfig libsel4 ./build/x86/pc99/libsel4/libsel4.a
5586a90067ee9e9f35520d31b0de4a6c04a0ac09  ./build/x86/pc99/libsel4/libsel4.a
87ef2bd4e1da9a397634edccf6101849067c9358  ./build/x86/pc99/libsel4/libsel4.a
^C
```
Running with the patch, gives the same sha for libsel4 even with many threads, but the build of the all target is not yet deterministic. All tests pass on x86_64.
```
[seL4test]$ . reproducible.sh 4 x64_simulation_debug_xml_defconfig libsel4 ./build/x86/pc99/libsel4/libsel4.a
475c4944cfe96894909fd8d47ecbbefbea21bc1f  ./build/x86/pc99/libsel4/libsel4.a
475c4944cfe96894909fd8d47ecbbefbea21bc1f  ./build/x86/pc99/libsel4/libsel4.a
475c4944cfe96894909fd8d47ecbbefbea21bc1f  ./build/x86/pc99/libsel4/libsel4.a
^C
[seL4test]$ . reproducible.sh 1 x64_simulation_debug_xml_defconfig libsel4 ./build/x86/pc99/libsel4/libsel4.a
475c4944cfe96894909fd8d47ecbbefbea21bc1f  ./build/x86/pc99/libsel4/libsel4.a
^C
[seL4test]$ . reproducible.sh 1 x64_simulation_debug_xml_defconfig all images/sel4test-driver-image-x86_64-pc99 
222a68b69bcd1ce9554b42d1255a1e3da1752f77  images/sel4test-driver-image-x86_64-pc99
cdf471a5d0698ee77a4f3d2077775a10b8b76b59  images/sel4test-driver-image-x86_64-pc99
^C
[seL4test]$ make x64_simulation_debug_xml_defconfig
[seL4test]$ make
[seL4test]$ make simulate-x86_64
...
Starting test 102: Test all tests ran
Test suite passed. 102 tests passed. 46 tests disabled.
All is well in the universe


QEMU 2.10.1 monitor - type 'help' for more information
(qemu) quit
[seL4test]$ repo branch
*  reproducible-ar           | in projects/tools
```