### PR TITLE
riscv: Add config options to run seL4 in RISC-V's Machine mode

### DIFF
--- a/common-tool/Makefile.flags
+++ b/common-tool/Makefile.flags
@@ -238,6 +238,12 @@ ifeq ($(CONFIG_ARCH_RISCV),y)
    export ARCH = riscv
    export PLAT = spike
 
+ifeq ($(CONFIG_SEL4_RV_MACHINE),y)
+   export PK_FLAGS = --enable-boot-machine
+else
+   export PK_FLAGS = --disable-boot-machine
+endif
+
 ifeq ($(CONFIG_ARCH_RISCV_RV64),y)
    ccflags-y += $(call cc-option, -march=rv64imac)
    ccflags-y += $(call cc-option, -mabi=lp64)

--- a/common-tool/project-riscv.mk
+++ b/common-tool/project-riscv.mk
@@ -48,7 +48,7 @@ elfloader: libcpio common FORCE
 	$(Q)(cd $(BUILD_BASE)/bbl && \
 	${TOOLS_ROOT}/riscv-pk/configure --quiet \
 		--host=$(CONFIG_CROSS_COMPILER_PREFIX:"%-"=%) \
-		--with-payload=$(IMAGE_ROOT)/$@-$(ARCH)-$(PLAT) && \
+	$(PK_FLAGS) --with-payload=$(IMAGE_ROOT)/$@-$(ARCH)-$(PLAT) && \
 	$(MAKE) $(MAKE_SILENT) clean && $(MAKE) $(MAKE_SILENT) > /dev/null)
 	$(Q)cp $(BUILD_BASE)/bbl/bbl $(IMAGE_ROOT)/$@-$(ARCH)-$(PLAT)
 

--- a/elfloader-tool/Kconfig
+++ b/elfloader-tool/Kconfig
@@ -73,6 +73,13 @@ config ARM_HYPERVISOR_MODE
 
 endchoice
 
+config SEL4_RV_MACHINE
+    bool "Run seL4 in Machine Mode"
+    default n
+    depends on ARCH_RISCV
+    help
+      Run seL4 in RISC-Vs Machine Mode
+
 config REMOVE_SYMBOLS
     bool "Remove ELF symbols from the final image"
     default y

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -84,6 +84,31 @@ map_kernel_window(struct image_info *kernel_info)
 #endif
 
 int num_apps = 0;
+
+#ifdef CONFIG_SEL4_RV_MACHINE
+void main(int hardid, unsigned long dtb)
+{
+    (void) hardid;
+    printf("ELF-loader started on\n");
+
+    printf("  paddr=[%p..%p]\n", _start, _end - 1);
+    /* Unpack ELF images into memory. */
+    load_images(&kernel_info, &user_info, 1, &num_apps);
+    if (num_apps != 1) {
+        printf("No user images loaded!\n");
+        abort();
+    }
+
+    printf("Jumping to kernel-image entry point...\n\n");
+
+    ((init_riscv_kernel_t)kernel_info.phys_region_start)(user_info.phys_region_start,
+                                            user_info.phys_region_end, user_info.phys_virt_offset,
+                                            user_info.virt_entry, 0, dtb);
+
+  /* We should never get here. */
+    printf("Kernel returned back to the elf-loader.\n");
+}
+#else
 void main(int hardid, unsigned long dtb)
 {
     (void) hardid;
@@ -117,3 +142,4 @@ void main(int hardid, unsigned long dtb)
   /* We should never get here. */
     printf("Kernel returned back to the elf-loader.\n");
 }
+#endif


### PR DESCRIPTION
This PR relies on riscv-pk's PR [here](https://github.com/riscv/riscv-pk/pull/104)