### PR TITLE
RISCV Level 2 Mappings

### DIFF
--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -3,11 +3,13 @@
  * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
  * ABN 41 687 119 230.
  *
+ * Copyright 2018, DornerWorks
+ *
  * This software may be distributed and modified according to the terms of
  * the GNU General Public License version 2. Note that NO WARRANTY is provided.
  * See "LICENSE_GPLv2.txt" for details.
  *
- * @TAG(DATA61_GPL)
+ * @TAG(DATA61_DORNERWORKS_GPL)
  */
 #include <autoconf.h>
 
@@ -18,6 +20,11 @@
 #include <abort.h>
 #include <cpio/cpio.h>
 
+#define PT_LEVEL_1 1
+#define PT_LEVEL_2 2
+
+#define PT_LEVEL_1_BITS 30
+#define PT_LEVEL_2_BITS 21
 
 #define PTE_TYPE_TABLE 0x00
 #define PTE_TYPE_SRWX 0xCE
@@ -28,14 +35,28 @@
 // page table entry (PTE) field
 #define PTE_V     0x001 // Valid
 
-#define PTE64_PPN0_SHIFT 10
+#define PTE_PPN0_SHIFT 10
 
-#define PTES_PER_PT (RISCV_PGSIZE/sizeof(long))
+#if __riscv_xlen == 32
+#define PTE_LEVEL_BITS PT_LEVEL_2_BITS
+#define PT_INDEX_BITS  10
+#define PPN_HIGH       20
+typedef uint32_t seL4_Word;
+#else
+#define PTE_LEVEL_BITS PT_LEVEL_1_BITS
+#define PT_INDEX_BITS  9
+#define PPN_HIGH       28
+typedef uint64_t seL4_Word;
+#endif
 
+#define PTES_PER_PT (1 << PT_INDEX_BITS)
 
-#define PTE64_CREATE(PPN, TYPE) (unsigned long) (((uint32_t)PPN) | (TYPE) | PTE_V)
-#define PTE64_PT_CREATE(PT_BASE) \
-  (((unsigned long)((unsigned long) PT_BASE) / RISCV_PGSIZE) << 10 | PTE_TYPE_TABLE | PTE_V)
+#define PTE_CREATE(PPN)          (unsigned long)(((uint32_t)PPN) | PTE_TYPE_SRWX | PTE_V)
+#define PTE_CREATE_PPN(PT_BASE)  (unsigned long)(((PT_BASE) >> RISCV_PGSHIFT) << PTE_PPN0_SHIFT)
+#define PTE_CREATE_NEXT(PT_BASE) (unsigned long)(PTE_CREATE_PPN(PT_BASE) | PTE_TYPE_TABLE | PTE_V)
+#define PTE_CREATE_LEAF(PT_BASE) (unsigned long)(PTE_CREATE_PPN(PT_BASE) | PTE_TYPE_SRWX | PTE_V)
+
+#define GET_PT_INDEX(addr, n) (((addr) >> (((PT_INDEX_BITS) * ((CONFIG_PT_LEVELS) - (n))) + RISCV_PGSHIFT)) % PTES_PER_PT)
 
 struct image_info kernel_info;
 struct image_info user_info;
@@ -46,24 +67,21 @@ char elfloader_stack_alloc[BIT(CONFIG_KERNEL_STACK_BITS)];
 void
 map_kernel_window(struct image_info *kernel_info)
 {
-    uint32_t i;
+    uint64_t i;
+    uint32_t l1_index;
+
     // first create a complete set of 1-to-1 mappings for all of memory. this is a brute
     // force way to ensure this elfloader is mapped into the new address space
-    for(i = 0; i < PTES_PER_PT; i++) {
-#if __riscv_xlen == 32
-        l1pt[i] = PTE64_CREATE((uint64_t)(i << 20), PTE_TYPE_SRWX);
-#else
-        l1pt[i] = PTE64_CREATE((uint64_t)(i << 28), PTE_TYPE_SRWX);
-#endif
+    for(i = 0; i < PTES_PER_PT; i++)
+    {
+        l1pt[i] = PTE_CREATE((uint64_t)(i << PPN_HIGH));
     }
     //Now create any neccessary entries for the kernel vaddr->paddr
-    i = (kernel_info->virt_region_start >> ((CONFIG_PT_LEVELS - 1) * (__riscv_xlen == 32 ? 10 : 9) + 12)) % PTES_PER_PT;
-    for (int page = 0; i < PTES_PER_PT; i++, page++) {
-#if __riscv_xlen == 32
-         l1pt[i] = PTE64_CREATE((uint32_t)((kernel_info->phys_region_start >> 12) + page) << 10, PTE_TYPE_SRWX);
-#else
-         l1pt[i] = PTE64_CREATE((uint64_t)((kernel_info->phys_region_start >> 12) + page) << PTE64_PPN0_SHIFT, PTE_TYPE_SRWX);
-#endif
+    l1_index = GET_PT_INDEX(kernel_info->virt_region_start, PT_LEVEL_1);
+
+    for (int page = 0; l1_index < PTES_PER_PT; l1_index++, page++)
+    {
+        l1pt[l1_index] = PTE_CREATE_LEAF((seL4_Word)(kernel_info->phys_region_start + page));
     }
 }
 

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -81,7 +81,7 @@ map_kernel_window(struct image_info *kernel_info)
 
     for (int page = 0; l1_index < PTES_PER_PT; l1_index++, page++)
     {
-        l1pt[l1_index] = PTE_CREATE_LEAF((seL4_Word)(kernel_info->phys_region_start + page));
+        l1pt[l1_index] = PTE_CREATE_LEAF((seL4_Word)(kernel_info->phys_region_start + (page << PTE_LEVEL_BITS)));
     }
 }
 


### PR DESCRIPTION
These commits support building 64-bit seL4 for the Rocket-Chip (https://github.com/ucb-bar/fpga-images-zedboard/tree/7e0080ee9e29e399d80d74d9756f20cece7aeef0)

Since the Rocket-Chip only has 256 MiB of RAM, its physical address is no longer aligned on a 1GiB boundary. These commits clean up the existing elfloader code to make things more readable, fix a simple bug, and then add another array for level 2 mappings which gets filled in if the ROCKET_CHIP config option is is selected (that is defined in the kernel, which is another pull request)