### PR TITLE
elfloader: Use kernel's version of the DTB

### DIFF
--- a/elfloader-tool/include/elfloader_common.h
+++ b/elfloader-tool/include/elfloader_common.h
@@ -66,7 +66,8 @@ extern char _archive_start_end[];
 
 /* Load images. */
 void load_images(struct image_info *kernel_info, struct image_info *user_info,
-                 int max_user_images, int *num_images, void **dtb, uint32_t *dtb_size);
+                 int max_user_images, int *num_images, void *bootloader_dtb, void **chosen_dtb,
+                 uint32_t *chosen_dtb_size);
 
 /* Platform functions */
 void platform_init(void);

--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -91,6 +91,8 @@ void main(UNUSED void *arg)
 {
     int num_apps;
 
+    void *bootloader_dtb = NULL;
+
 #ifdef CONFIG_IMAGE_UIMAGE
     if (arg) {
         uint32_t magic = *(uint32_t *)arg;
@@ -104,9 +106,9 @@ void main(UNUSED void *arg)
             arg = NULL;
         }
     }
-    dtb = arg;
+    bootloader_dtb = arg;
 #else
-    dtb = NULL;
+    bootloader_dtb = NULL;
 #endif
 
 #ifdef CONFIG_IMAGE_EFI
@@ -115,7 +117,7 @@ void main(UNUSED void *arg)
         abort();
     }
 
-    dtb = efi_get_fdt();
+    bootloader_dtb = efi_get_fdt();
 #endif
 
     /* Print welcome message. */
@@ -129,14 +131,14 @@ void main(UNUSED void *arg)
      * U-Boot will either pass us a DTB, or (if we're being booted via bootelf)
      * pass '0' in argc.
      */
-    if (dtb) {
+    if (bootloader_dtb) {
         printf("  dtb=%p\n", dtb);
     } else {
         printf("No DTB passed in from boot loader.\n");
     }
 
     /* Unpack ELF images into memory. */
-    load_images(&kernel_info, &user_info, 1, &num_apps, &dtb, &dtb_size);
+    load_images(&kernel_info, &user_info, 1, &num_apps, bootloader_dtb, &dtb, &dtb_size);
     if (num_apps != 1) {
         printf("No user images loaded!\n");
         abort();

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -161,14 +161,17 @@ static inline void enable_virtual_memory(void)
 }
 
 int num_apps = 0;
-void main(UNUSED int hartid, void *dtb)
+void main(UNUSED int hardid, void *bootloader_dtb)
 {
-    uint32_t dtb_size;
+    void *dtb = NULL;
+    uint32_t dtb_size = 0;
     printf("ELF-loader started on (HART %d) (NODES %d)\n", hartid, CONFIG_MAX_NUM_NODES);
 
     printf("  paddr=[%p..%p]\n", _start, _end - 1);
-    /* Unpack ELF images into memory. */
-    load_images(&kernel_info, &user_info, 1, &num_apps, &dtb, &dtb_size);
+    /* Unpack ELF images into memory.
+     * Note that we do not pass the bootloader's DTB as
+     * we want to use the kernel's version of the DTB. */
+    load_images(&kernel_info, &user_info, 1, &num_apps, bootloader_dtb, &dtb, &dtb_size);
     if (num_apps != 1) {
         printf("No user images loaded!\n");
         abort();
@@ -196,7 +199,7 @@ void main(UNUSED int hartid, void *dtb)
                                                   hartid,
                                                   0
 #endif
-                                                  );
+                                                 );
 
     /* We should never get here. */
     printf("Kernel returned back to the elf-loader.\n");
@@ -219,7 +222,7 @@ void secondary_entry(int hart_id, int core_id)
                                                   ,
                                                   hart_id,
                                                   core_id
-                                                  );
+                                                 );
 }
 
 #endif


### PR DESCRIPTION
Instead of using the bootloader's version of the DTB, we use and passthrough the kernel's version of the DTB (if any). This is because other tools rely on the assumption that the DTB that's passed from the kernel to userland is the same as the kernel's version of the DTB.