### PR TITLE
use CR LF as line break and not LF CR

### DIFF
--- a/elfloader-tool/src/arch-riscv/sys_fputc.c
+++ b/elfloader-tool/src/arch-riscv/sys_fputc.c
@@ -19,6 +19,7 @@
 
 int __fputc(int c, UNUSED FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
     if (c == '\n') {
         sbi_console_putchar('\r');
     }

--- a/elfloader-tool/src/binaries/efi/efi_fputc.c
+++ b/elfloader-tool/src/binaries/efi/efi_fputc.c
@@ -19,14 +19,16 @@ int efi_fputc(int c, UNUSED FILE *stream)
     /* obtain a pointer to EFI output console */
     efi_simple_text_output_protocol_t * efi_console_out = get_efi_con_out();
 
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n')
+    {
+        /* EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL only accepts unicode chars */
+        uint16_t cr[2] = { '\r', 0 };
+        efi_console_out->output_string(efi_console_out, cr);
+    }
+
     /* EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL only accepts unicode chars */
     uint16_t char_to_print[2] = { c, 0 };
-
-    if (char_to_print[0] == '\n')
-    {
-        uint16_t nl[2] = { '\r', 0 };
-        efi_console_out->output_string(efi_console_out, nl);
-    }
     efi_console_out->output_string(efi_console_out, char_to_print);
 
     return 0;

--- a/elfloader-tool/src/plat/am335x/sys_fputc.c
+++ b/elfloader-tool/src/plat/am335x/sys_fputc.c
@@ -33,16 +33,16 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
 
     /* Add character to the buffer. */
     *UART_REG(UTHR) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/apq8064/sys_fputc.c
+++ b/elfloader-tool/src/plat/apq8064/sys_fputc.c
@@ -36,17 +36,17 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, UNUSED FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait for TX fifo to be empty */
     while (!(*UART_REG(USR) & USR_TXEMP));
     /* Tell the peripheral how many characters to send */
     *UART_REG(UNTX) = 1;
     /* Write the character into the FIFO */
     *UART_REG(UTF) = c & 0xff;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/bcm2837/sys_fputc.c
+++ b/elfloader-tool/src/plat/bcm2837/sys_fputc.c
@@ -53,16 +53,16 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while (!(*UART_REG(MU_LSR) & MU_LSR_TXIDLE));
 
     /* Put in the register to be sent*/
     *UART_REG(MU_IO) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/exynos4/sys_fputc.c
+++ b/elfloader-tool/src/plat/exynos4/sys_fputc.c
@@ -52,16 +52,16 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while (!(*UART_REG(UTRSTAT) & TXBUF_EMPTY));
 
     /* Put in the register to be sent*/
     *UART_REG(UTXH) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/exynos5/sys_fputc.c
+++ b/elfloader-tool/src/plat/exynos5/sys_fputc.c
@@ -52,16 +52,16 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while (!(*UART_REG(UTRSTAT) & TXBUF_EMPTY));
 
     /* Put in the register to be sent*/
     *UART_REG(UTXH) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/fvp/sys_fputc.c
+++ b/elfloader-tool/src/plat/fvp/sys_fputc.c
@@ -21,16 +21,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(UARTFR) & UARTFR_TXFF) != 0);
 
     /* Add character to the buffer. */
     *UART_REG(UARTDR) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/hikey/sys_fputc.c
+++ b/elfloader-tool/src/plat/hikey/sys_fputc.c
@@ -22,16 +22,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(UARTFR) & UARTFR_TXFF) != 0);
 
     /* Add character to the buffer. */
     *UART_REG(UARTDR) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/imx31/sys_fputc.c
+++ b/elfloader-tool/src/plat/imx31/sys_fputc.c
@@ -41,16 +41,16 @@
 
 int __fputc(int c, UNUSED FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait to be able to transmit. */
     while (!(*UART_REG(UART_STAT2) & TXFE));
 
     /* Transmit. */
     *UART_REG(UART_TRANSMIT) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/imx6/sys_fputc.c
+++ b/elfloader-tool/src/plat/imx6/sys_fputc.c
@@ -34,16 +34,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait to be able to transmit. */
     while (!(*UART_REG(UART_STAT2) & TXFE));
 
     /* Transmit. */
     *UART_REG(UART_TRANSMIT) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/imx7/sys_fputc.c
+++ b/elfloader-tool/src/plat/imx7/sys_fputc.c
@@ -34,16 +34,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait to be able to transmit. */
     while (!(*UART_REG(UART_STAT2) & TXFE));
 
     /* Transmit. */
     *UART_REG(UART_TRANSMIT) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/imx8mq-evk/sys_fputc.c
+++ b/elfloader-tool/src/plat/imx8mq-evk/sys_fputc.c
@@ -34,16 +34,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait to be able to transmit. */
     while (!(*UART_REG(UART_STAT2) & TXFE));
 
     /* Transmit. */
     *UART_REG(UART_TRANSMIT) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/odroidc2/sys_fputc.c
+++ b/elfloader-tool/src/plat/odroidc2/sys_fputc.c
@@ -22,14 +22,16 @@
 
 int __fputc(int c, FILE *stream)
 {
-
-    while ((*UART_REG(UART_STATUS) & UART_TX_FULL));
-    *UART_REG(UART_WFIFO) = c;
-
-    /* Send '\r' after every '\n'. */
+    /* Send '\r' (CR) before every '\n' (LF). */
     if (c == '\n') {
         (void)__fputc('\r', stream);
     }
+
+    /* Wait to be able to transmit. */
+    while ((*UART_REG(UART_STATUS) & UART_TX_FULL));
+
+    /* Transmit. */
+    *UART_REG(UART_WFIFO) = c;
 
     return 0;
 }

--- a/elfloader-tool/src/plat/omap3/sys_fputc.c
+++ b/elfloader-tool/src/plat/omap3/sys_fputc.c
@@ -33,16 +33,16 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
 
     /* Add character to the buffer. */
     *UART_REG(UTHR) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/qemu-arm-virt/sys_fputc.c
+++ b/elfloader-tool/src/plat/qemu-arm-virt/sys_fputc.c
@@ -22,16 +22,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(UARTFR) & UARTFR_TXFF) != 0);
 
     /* Add character to the buffer. */
     *UART_REG(UARTDR) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/rockpro64/sys_fputc.c
+++ b/elfloader-tool/src/plat/rockpro64/sys_fputc.c
@@ -33,16 +33,16 @@ __fputc(int c, FILE *stream);
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
 
     /* Add character to the buffer. */
     *UART_REG(UTHR) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/tk1/sys_fputc.c
+++ b/elfloader-tool/src/plat/tk1/sys_fputc.c
@@ -26,14 +26,16 @@
 
 int __fputc(int c, FILE *stream)
 {
-
-    while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
-
-    *UART_REG(UTHR) = (c & 0xff);
-
+    /* Send '\r' (CR) before every '\n' (LF). */
     if (c == '\n') {
         __fputc('\r', stream);
     }
+
+    /* Wait to be able to transmit. */
+    while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
+
+    /* Transmit. */
+    *UART_REG(UTHR) = (c & 0xff);
 
     return 0;
 }

--- a/elfloader-tool/src/plat/tx1/sys_fputc.c
+++ b/elfloader-tool/src/plat/tx1/sys_fputc.c
@@ -22,16 +22,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
 
     /* Add character to the buffer. */
     *UART_REG(UTHR) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/tx2/sys_fputc.c
+++ b/elfloader-tool/src/plat/tx2/sys_fputc.c
@@ -22,16 +22,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait until UART ready for the next character. */
     while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
 
     /* Add character to the buffer. */
     *UART_REG(UTHR) = (c & 0xff);
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/zynq7000/sys_fputc.c
+++ b/elfloader-tool/src/plat/zynq7000/sys_fputc.c
@@ -49,16 +49,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait to be able to transmit. */
     while (!(*UART_REG(UART_CHANNEL_STS) & UART_CHANNEL_STS_TXEMPTY));
 
     /* Transmit. */
     *UART_REG(UART_TX_RX_FIFO) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }

--- a/elfloader-tool/src/plat/zynqmp/sys_fputc.c
+++ b/elfloader-tool/src/plat/zynqmp/sys_fputc.c
@@ -42,16 +42,16 @@
 
 int __fputc(int c, FILE *stream)
 {
+    /* Send '\r' (CR) before every '\n' (LF). */
+    if (c == '\n') {
+        (void)__fputc('\r', stream);
+    }
+
     /* Wait to be able to transmit. */
     while (!(*UART_REG(XUARTPS_SR) & XUARTPS_SR_TXEMPTY));
 
     /* Transmit. */
     *UART_REG(XUARTPS_FIFO) = c;
-
-    /* Send '\r' after every '\n'. */
-    if (c == '\n') {
-        (void)__fputc('\r', stream);
-    }
 
     return 0;
 }


### PR DESCRIPTION
I've been wondering about this for some time, is there a reason why LF CR is used and all elfloader logs contain an empty line between each line (on many systems). Or is this just a mistake and it should always have been CR LF actually?