### PR TITLE
Don't attempt to build hosted programs to test GCC

### DIFF
--- a/cmake-tool/helpers/environment_flags.cmake
+++ b/cmake-tool/helpers/environment_flags.cmake
@@ -96,10 +96,10 @@ macro(add_fpu_compilation_options)
         function(SimpleCCompilationTest var flags)
             if(NOT (DEFINED "${var}"))
                 message(STATUS "Performing test ${var} with flags ${flags}")
-                file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/test_program.c" "void main(void){}")
+                file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/test_program.c" "void _start(void){}")
                 execute_process(
                     COMMAND
-                        "${CMAKE_C_COMPILER}" ${flags} -o test_program test_program.c
+                        "${CMAKE_C_COMPILER}" ${flags} -nostartfiles -nostdlib -o test_program test_program.c
                     RESULT_VARIABLE result
                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
                     OUTPUT_QUIET ERROR_QUIET

--- a/cmake-tool/helpers/environment_flags.cmake
+++ b/cmake-tool/helpers/environment_flags.cmake
@@ -84,7 +84,6 @@ macro(find_libgcc_files)
     endif()
 endmacro()
 
-
 macro(add_fpu_compilation_options)
     # We want to check what we can set the -mfloat-abi to on arm and if that matches what is requested
     if(KernelSel4ArchAarch64)
@@ -99,7 +98,8 @@ macro(add_fpu_compilation_options)
                 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/test_program.c" "void _start(void){}")
                 execute_process(
                     COMMAND
-                        "${CMAKE_C_COMPILER}" ${flags} -nostartfiles -nostdlib -o test_program test_program.c
+                        "${CMAKE_C_COMPILER}" ${flags} -nostartfiles -nostdlib -o test_program
+                        test_program.c
                     RESULT_VARIABLE result
                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
                     OUTPUT_QUIET ERROR_QUIET
@@ -120,7 +120,9 @@ macro(add_fpu_compilation_options)
             if(NOT HARD_FLOAT)
                 SimpleCCompilationTest(SOFTFP_FLOAT "-mfloat-abi=softfp")
                 if(NOT SOFTFP_FLOAT)
-                    message(WARNING "Kernel supports hardware floating point but toolchain does not")
+                    message(
+                        WARNING "Kernel supports hardware floating point but toolchain does not"
+                    )
                     add_compile_options(-mfloat-abi=soft)
                 else()
                     add_compile_options(-mfloat-abi=softfp)


### PR DESCRIPTION
By building a program which provides `main()`, we were assuming that
there is a libc available to compiler. This is not the case for the Red
Hat provided cross-compilers which are intended for use in freestanding
environments (the example given is kernel code). Given that the seL4
build system assumes a freestanding environment it is sensible to only
check that the compiler being used is capable of building such programs.

This change alters the code built when testing compiler options in
`environment_flags.cmake`, and also adds fixed options to force the
compiler to not link against the stdlib or include crt objects. By doing
so we avoid any requirement for a target libc on the build host.