### PR TITLE
riscv: Fix 32-bit hart and core ID passing

### DIFF
--- a/elfloader-tool/include/arch-riscv/elfloader.h
+++ b/elfloader-tool/include/arch-riscv/elfloader.h
@@ -17,7 +17,7 @@ typedef void (*init_riscv_kernel_t)(paddr_t ui_p_reg_start,
                                     uint32_t dtb_size
 #if CONFIG_MAX_NUM_NODES > 1
                                     ,
-                                    uint64_t hart_id,
-                                    uint64_t core_id
+                                    word_t hart_id,
+                                    word_t core_id
 #endif
                                    );


### PR DESCRIPTION
The kernel entry uses word_t and expects values in a4 and a5.

Without this, all harts think they are primary and the kernel setup code gets very confused.