### PR TITLE
CMake: remove debug output artifact

### DIFF
--- a/cmake-tool/helpers/environment_flags.cmake
+++ b/cmake-tool/helpers/environment_flags.cmake
@@ -72,7 +72,7 @@ macro(gcc_print_file_name var file)
         separate_arguments(c_arguments UNIX_COMMAND "${CMAKE_C_FLAGS}")
         # Append the target flag to the arguments if we are using clang so the
         # correct crt files are found
-        if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
             list(APPEND c_arguments "${CMAKE_C_COMPILE_OPTIONS_TARGET}${CMAKE_C_COMPILER_TARGET}")
         endif()
         execute_process(

--- a/cmake-tool/helpers/environment_flags.cmake
+++ b/cmake-tool/helpers/environment_flags.cmake
@@ -57,9 +57,14 @@ macro(add_default_compilation_options)
     # uses causes alignment checks to be enabled.
     if(KernelSel4ArchAarch64)
         add_compile_options(-mstrict-align)
-        EXECUTE_PROCESS(COMMAND gcc -dumpversion CMAKE_C_COMPILER_VERSION)
-        set(GCC_10 "10.0.0")
-        if(${CMAKE_C_COMPILER_VERSION} VERSION_GREATER_EQUAL ${GCC_10})
+        if(NOT CMAKE_C_COMPILER_VERSION)
+            message(FATAL_ERROR "CMAKE_C_COMPILER_VERSION is not set")
+        endif()
+        # special handling for GCC 10 and above
+        if(
+            (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+            AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "10.0.0")
+        )
             add_compile_options(-mno-outline-atomics)
         endif()
     elseif(KernelSel4ArchAarch32)


### PR DESCRIPTION
The variable CMAKE_C_COMPILER_VERSION should be set by CMake already,
printing the generic gcc output seem just a artifact from testing. If
the output of this command should be captured to overwrite the variable
CMAKE_C_COMPILER_VERSION, then the keyword OUTPUT_VARIABLE is missing.
But even then, the proper cross compiler must be called using
${CROSS_COMPILER_PREFIX}gcc for this to make sense.
