### PR TITLE
Inital support for RK3288

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.8.2)
 include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
-    set(binary_list "tx1;hikey;odroidc2;imx8mq-evk;rockpro64;zynqmp;imx8mm-evk;hifive")
+    set(binary_list "tx1;hikey;odroidc2;imx8mq-evk;rockpro64;zynqmp;imx8mm-evk;hifive;rk3288")
     set(efi_list "tk1")
     set(uimage_list "tx2;am335x")
     if(
@@ -45,7 +45,7 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         set(IMAGE_START_ADDR 0x8000000 CACHE INTERNAL "" FORCE)
     endif()
     if(${kernel_platform} STREQUAL "rk3288")
-        set(IMAGE_START_ADDR 0x00800000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR 0x008000000 CACHE INTERNAL "" FORCE)
     endif()
 endfunction()
 

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -44,6 +44,9 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     if(KernelPlatformZynqmp AND KernelSel4ArchAarch32)
         set(IMAGE_START_ADDR 0x8000000 CACHE INTERNAL "" FORCE)
     endif()
+    if(${kernel_platform} STREQUAL "rk3288")
+	set(IMAGE_START_ADDR 0x02008000 CACHE INTERNAL "" FORCE)
+    endif()
 endfunction()
 
 function(ApplyCommonSimulationSettings kernel_arch)
@@ -103,6 +106,7 @@ function(correct_platform_strings)
         wandq
         kzm
         rpi3
+        rk3288-ntablet
         exynos5250
         exynos5410
         exynos5422
@@ -140,6 +144,9 @@ function(correct_platform_strings)
     elseif("${PLATFORM}" STREQUAL "am335x-boneblue")
         set(KernelPlatform am335x CACHE STRING "" FORCE)
         set(KernelARMPlatform am335x-boneblue CACHE STRING "" FORCE)
+    elseif("${PLATFORM}" STREQUAL "rk3288-ntablet")
+	set(KernelPlatform rk3288 CACHE STRING "" FORCE)
+	set(KernelARMPlatform rk3288-ntablet CACHE STRING "" FORCE)
     elseif("${PLATFORM}" STREQUAL "x86_64")
         set(KernelPlatform pc99 CACHE STRING "" FORCE)
         set(KernelSel4Arch x86_64 CACHE STRING "" FORCE)

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -45,7 +45,7 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         set(IMAGE_START_ADDR 0x8000000 CACHE INTERNAL "" FORCE)
     endif()
     if(${kernel_platform} STREQUAL "rk3288")
-	set(IMAGE_START_ADDR 0x02008000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR 0x00800000 CACHE INTERNAL "" FORCE)
     endif()
 endfunction()
 
@@ -106,7 +106,6 @@ function(correct_platform_strings)
         wandq
         kzm
         rpi3
-        rk3288-ntablet
         exynos5250
         exynos5410
         exynos5422
@@ -144,9 +143,6 @@ function(correct_platform_strings)
     elseif("${PLATFORM}" STREQUAL "am335x-boneblue")
         set(KernelPlatform am335x CACHE STRING "" FORCE)
         set(KernelARMPlatform am335x-boneblue CACHE STRING "" FORCE)
-    elseif("${PLATFORM}" STREQUAL "rk3288-ntablet")
-	set(KernelPlatform rk3288 CACHE STRING "" FORCE)
-	set(KernelARMPlatform rk3288-ntablet CACHE STRING "" FORCE)
     elseif("${PLATFORM}" STREQUAL "x86_64")
         set(KernelPlatform pc99 CACHE STRING "" FORCE)
         set(KernelSel4Arch x86_64 CACHE STRING "" FORCE)

--- a/elfloader-tool/src/arch-arm/armv/armv7-a/32/mmu-hyp.S
+++ b/elfloader-tool/src/arch-arm/armv/armv7-a/32/mmu-hyp.S
@@ -81,5 +81,7 @@ BEGIN_FUNC(arm_enable_hyp_mmu)
     mcr     p15, 0, r0, c1, c0, 1
 #endif /* CONFIG_MAX_NUM_NODES > 1 */
 
+	isb sy
+
     ldmfd   sp!, {pc}
 END_FUNC(arm_enable_hyp_mmu)


### PR DESCRIPTION
Using the Yeacreate NTablet as the platform, this patch series adds
support for the Rockchip RK3288.

Signed-off-by: Peter Chubb <peter.chubb@data61.csiro.au>

Test with: seL4/seL4#280