### PR TITLE
camke/elfloader add i.MX6 Nitrogen6_SoloX board

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2020, HENSOLDT Cyber GmbH
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -153,7 +154,7 @@ function(correct_platform_strings)
         # configuration to <sel4 kernel>/src/plat/*/config.cmake
         #
         "-KernelARMPlatform"
-        "imx6:sabre,wandq"
+        "imx6:sabre,wandq,nitrogen6sx"
         "imx31:kzm"
         "bcm2837:rpi3"
         "bcm2711:rpi4"

--- a/elfloader-tool/src/arch-arm/drivers/smp-imx6.c
+++ b/elfloader-tool/src/arch-arm/drivers/smp-imx6.c
@@ -1,5 +1,7 @@
 /*
  * Copyright Linux Kernel team
+ * Copyright 2020, HENSOLDT Cyber GmbH
+ *
  * SPDX-License-Identifier: GPL-2.0-only
  *
  * The code in here is loosely derived from the Linux kernel
@@ -85,6 +87,7 @@ static int smp_imx6_init(UNUSED struct elfloader_device *dev,
 
 static const struct dtb_match_table smp_imx6_matches[] = {
     { .compatible = "fsl,imx6q-src" },
+    { .compatible = "fsl,imx6sx-src" },
     { .compatible = NULL /* sentinel */ },
 };
 

--- a/elfloader-tool/src/drivers/uart/imx-uart.c
+++ b/elfloader-tool/src/drivers/uart/imx-uart.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -46,6 +47,7 @@ static int imx_uart_init(struct elfloader_device *dev, UNUSED void *match_data)
 static const struct dtb_match_table imx_uart_matches[] = {
     { .compatible = "fsl,imx31-uart" },
     { .compatible = "fsl,imx6q-uart" },
+    { .compatible = "fsl,imx6sx-uart" },
     { .compatible = NULL /* sentinel */ },
 };
 

--- a/elfloader-tool/src/plat/imx6/monitor.S
+++ b/elfloader-tool/src/plat/imx6/monitor.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -12,7 +13,13 @@
 #error This file is for CONFIG_ARM_MONITOR_HOOK only
 #endif
 
+#if defined(CONFIG_PLAT_IMX6DQ)
 #define VECTOR_BASE     0x10000000
+#elif defined(CONFIG_PLAT_IMX6SX)
+#define VECTOR_BASE     0x80000000
+#else
+#error "unknown i.MX6 SOC"
+#endif
 #define STACK_TOP       (VECTOR_BASE + (1 << 12) - 0x10)
 
 /* vector table for monitor mode

--- a/elfloader-tool/src/plat/imx6/platform_init.c
+++ b/elfloader-tool/src/plat/imx6/platform_init.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -107,8 +108,13 @@ UNUSED static void switch_to_mon_mode(void)
 /* The physical address region [MON_VECTOR_START, MON_VECTOR_START + size)
  * must not be used by the seL4 kernel. The VECTOR_BASE must be
  * the same as MON_VECTOR_START */
-
+#if defined(CONFIG_PLAT_IMX6DQ)
 #define MON_VECTOR_START    (0x10000000)
+#elif defined(CONFIG_PLAT_IMX6SX)
+#define MON_VECTOR_START    (0x80000000)
+#else
+#error "unknown i.MX6 SOC"
+#endif
 extern void arm_monitor_vector(void);
 extern void arm_monitor_vector_end(void);
 extern void *memcpy(void *dest, void *src, size_t n);


### PR DESCRIPTION
Patch is part of a series of patches to add support for the i.MX6 Nitrogen6_SoloX board
* https://github.com/seL4/camkes-tool/pull/57
* https://github.com/seL4/seL4/pull/309