### PR TITLE
exclude monitor.S is CONFIG_ARM_MONITOR_HOOK is not active

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -173,6 +173,12 @@ file(
 # We never want to give crt0_64.S to add_executable
 list(FILTER files EXCLUDE REGEX src/arch-arm/32/crt0_64.S)
 
+if(NOT ElfloaderMonitorHook)
+    # The CMake documentation is no clear on this, but it seems all variables
+    # of the form ${xxx} get evaluated first and then the regex is applied
+    list(FILTER files EXCLUDE REGEX "src/plat/${KernelPlatform}/monitor\.S")
+endif()
+
 if(KernelArchARM)
     file(
         GLOB

--- a/elfloader-tool/src/plat/imx6/monitor.S
+++ b/elfloader-tool/src/plat/imx6/monitor.S
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#ifndef CONFIG_ARM_MONITOR_HOOK
+#error This file is for CONFIG_ARM_MONITOR_HOOK only
+#endif
+
+
 #include <autoconf.h>
 #include <elfloader/gen_config.h>
 

--- a/elfloader-tool/src/plat/tk1/monitor.S
+++ b/elfloader-tool/src/plat/tk1/monitor.S
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#ifndef CONFIG_ARM_MONITOR_HOOK
+#error This file is for CONFIG_ARM_MONITOR_HOOK only
+#endif
+
+
 #include <autoconf.h>
 #include <elfloader/gen_config.h>
 


### PR DESCRIPTION
address https://github.com/seL4/seL4_tools/issues/47 and exclude monitor.S is CONFIG_ARM_MONITOR_HOOK is not active