### PR TITLE
CMake: fix regex to use the dot correctly

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -171,7 +171,7 @@ file(
 )
 
 # We never want to give crt0_64.S to add_executable
-list(FILTER files EXCLUDE REGEX src/arch-arm/32/crt0_64.S)
+list(FILTER files EXCLUDE REGEX "src/arch-arm/32/crt0_64\.S")
 
 if(KernelArchARM)
     file(


### PR DESCRIPTION
fix regex to use the dot correctly, we expect really a dot here and not "any" chars (which also matched the dot, but it seem semantically wrong)