### PR TITLE
[risc-V] switch to HART 1 on boot

### DIFF
--- a/elfloader-tool/include/arch-riscv/sbi.h
+++ b/elfloader-tool/include/arch-riscv/sbi.h
@@ -31,6 +31,25 @@
     a0;                         \
 })
 
+#define  SBI_HSM 0x48534DULL
+#define  SBI_HSM_HART_START 0
+
+#define SBI_EXT_CALL(extension, which, arg0, arg1, arg2) ({  \
+    register uintptr_t a0 asm ("a0") = (uintptr_t)(arg0);   \
+    register uintptr_t a1 asm ("a1") = (uintptr_t)(arg1);   \
+    register uintptr_t a2 asm ("a2") = (uintptr_t)(arg2);   \
+    register uintptr_t a7 asm ("a6") = (uintptr_t)(which);  \
+    register uintptr_t a6 asm ("a7") = (uintptr_t)extension; \
+    asm volatile ("ecall"                   \
+              : "+r" (a0)               \
+              : "r" (a1), "r" (a2), "r" (a7), "r" (a6)      \
+              : "memory");              \
+    a0;                         \
+})
+
+#define SBI_HSM_CALL(which, arg0, arg1, arg2) \
+    SBI_EXT_CALL(SBI_HSM, (which), (arg0), (arg1), (arg2))
+
 /* Lazy implementations until SBI is finalized */
 #define SBI_CALL_0(which) SBI_CALL(which, 0, 0, 0)
 #define SBI_CALL_1(which, arg0) SBI_CALL(which, arg0, 0, 0)
@@ -88,4 +107,11 @@ static inline void sbi_remote_sfence_vma_asid(const unsigned long *hart_mask,
                                               UNUSED unsigned long asid)
 {
     SBI_CALL_1(SBI_REMOTE_SFENCE_VMA_ASID, hart_mask);
+}
+
+static inline void sbi_hart_start(const unsigned long hart_id,
+                                  void (*start)(unsigned long),
+                                  unsigned long privilege)
+{
+    SBI_HSM_CALL(SBI_HSM_HART_START, hart_id, start, privilege);
 }

--- a/elfloader-tool/src/arch-riscv/crt0.S
+++ b/elfloader-tool/src/arch-riscv/crt0.S
@@ -23,10 +23,28 @@ _start:
 .option pop
 
 /* OpenSBI starts all HARTs and sends them to this entry point. */
-  li s0, CONFIG_FIRST_HART_ID
-  bne  a0, s0, secondary_harts
+//  li s0, CONFIG_FIRST_HART_ID
+//  bne  a0, s0, secondary_harts
 
   la sp, (elfloader_stack_alloc + BIT(12))
+
+  la s0, main
+  jr s0
+
+.global _start_1
+_start_1:
+
+.option push
+.option norelax
+1:auipc gp, %pcrel_hi(__global_pointer$)
+  addi  gp, gp, %pcrel_lo(1b)
+.option pop
+
+/* OpenSBI starts all HARTs and sends them to this entry point. */
+//  li s0, CONFIG_FIRST_HART_ID
+//  bne  a0, s0, secondary_harts
+
+  la sp, (elfloader_stack_alloc + BIT(12) - 1024)
 
   la s0, main
   jr s0
@@ -41,6 +59,7 @@ bootstack_secondary_cores:
 
 .text
 
+.global secondary_harts
 secondary_harts:
 #if CONFIG_MAX_NUM_NODES > 1
   la a1, next_logical_core_id


### PR DESCRIPTION
The seL4 kernel and libraries currentl assume they are running
on the first HART in the system.

OpenSBI and U-Boot pick a HART at random to start on.
This patch uses an SBI call to start HART 1 and run the elfloader on it if
at boot time a different HART has been chosen.

This is a first straw-man example of how it might be done.
Signed-off-by: Peter Chubb <peter.chubb@data61.csiro.au>