### PR TITLE
fix ElfloaderMonitorHook check

### DIFF
--- a/elfloader-tool/src/plat/imx6/monitor.S
+++ b/elfloader-tool/src/plat/imx6/monitor.S
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
-#ifndef CONFIG_ARM_MONITOR_HOOK
-#error This file is for CONFIG_ARM_MONITOR_HOOK only
-#endif
-
 
 #include <autoconf.h>
 #include <elfloader/gen_config.h>
+
+#ifndef CONFIG_ARM_MONITOR_HOOK
+#error This file is for CONFIG_ARM_MONITOR_HOOK only
+#endif
 
 #define VECTOR_BASE     0x10000000
 #define STACK_TOP       (VECTOR_BASE + (1 << 12) - 0x10)

--- a/elfloader-tool/src/plat/tk1/monitor.S
+++ b/elfloader-tool/src/plat/tk1/monitor.S
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
-#ifndef CONFIG_ARM_MONITOR_HOOK
-#error This file is for CONFIG_ARM_MONITOR_HOOK only
-#endif
-
 
 #include <autoconf.h>
 #include <elfloader/gen_config.h>
+
+#ifndef CONFIG_ARM_MONITOR_HOOK
+#error This file is for CONFIG_ARM_MONITOR_HOOK only
+#endif
 
 #define VECTOR_BASE     0xa7f00000
 #define STACK_TOP       (VECTOR_BASE + (1 << 20) - 0x10)


### PR DESCRIPTION
The check in elfloader-tool/src/plat/imx6/monitor.S and elfloader-tool/src/plat/tk1/monitor.S must be done after including gen_config.