### PR TITLE
risc-v: switch to hart1

### DIFF
--- a/elfloader-tool/src/arch-riscv/crt0.S
+++ b/elfloader-tool/src/arch-riscv/crt0.S
@@ -6,14 +6,22 @@
 
 #include <autoconf.h>
 #include <elfloader/gen_config.h>
+
 .extern main
-.global _start
 .extern __global_pointer$
 .extern elfloader_stack_alloc
+.extern hsm_exists
 
 #define BIT(n) (1 << (n))
+#define SBI_HSM_BASE 0x48534DULL
+#define SBI_HSM_BASE_HART_START 0
+#define SBI_EXT_BASE 0x10
+#define SBI_EXT_BASE_PROBE_EXT 3
+
 .section ".text.start"
 
+/* OpenSBI starts all HARTs and sends them to this entry point. */
+.global _start
 _start:
 
 .option push
@@ -22,7 +30,48 @@ _start:
   addi  gp, gp, %pcrel_lo(1b)
 .option pop
 
-/* OpenSBI starts all HARTs and sends them to this entry point. */
+/* a0 should have hart id, store it in temp so as not to clobber from HSM calls */
+  mv t3, a0
+
+/* Check Heart State Management extension exists so we can use that to switch harts
+   if we are not hart 1, otherwise rely on the legacy extension. */
+
+/* sbi_probe_extension: Returns 0 if the given SBI extension ID (EID) is not available,
+   or an extension-specific non-zero value if it is available.*/
+
+  jal spi_probe_extension
+  mv a0, t3
+  li s1, 1
+  blt x1, s1, _start1
+
+/* Update bool to tell boot code HSM exists */
+  la t1, hsm_exists
+  li t2, 1
+  amoadd.w t1, t2, (t1)
+
+  mv a0, t3
+  li s0, CONFIG_FIRST_HART_ID
+  beq  a0, s0, _start1
+
+/* start hart 1*/
+hsm_switch_hart:
+  li a7, SBI_HSM_BASE
+  li a6, SBI_HSM_BASE_HART_START
+  li a0, 1       // hart id to start
+  la a1, _start1 // where to start new hart
+  li a2, 0       // passed in a1 when new hart starts, this is the logical hart_id
+  ecall
+
+  j secondary_harts
+
+_start1:
+
+.option push
+.option norelax
+1:auipc gp, %pcrel_hi(__global_pointer$)
+  addi  gp, gp, %pcrel_lo(1b)
+.option pop
+
   li s0, CONFIG_FIRST_HART_ID
   bne  a0, s0, secondary_harts
 
@@ -41,15 +90,24 @@ bootstack_secondary_cores:
 
 .text
 
+.global secondary_harts
 secondary_harts:
+
+.option push
+.option norelax
+1:auipc gp, %pcrel_hi(__global_pointer$)
+  addi  gp, gp, %pcrel_lo(1b)
+.option pop
+
 #if CONFIG_MAX_NUM_NODES > 1
   la a1, next_logical_core_id
   li t2, 1
-  amoadd.w a1, t2, (a1)
+  amoadd.w t0, t2, (a1)
   /* now a1 has the logical core id */
   li t2, CONFIG_MAX_NUM_NODES
-  bge a1, t2, spin_hart
-  mv t0, a1
+  bge t0, t2, spin_hart
+
+  mv a1, t0
   slli t0, t0, 12
   la sp, bootstack_secondary_cores
   add sp, sp, t0
@@ -59,3 +117,10 @@ secondary_harts:
 spin_hart:
   wfi
   j spin_hart
+
+spi_probe_extension:
+  li a7, SBI_EXT_BASE
+  li a6, SBI_EXT_BASE_PROBE_EXT
+  li a0, SBI_HSM_BASE
+  ecall
+  ret


### PR DESCRIPTION
seL4 and librarys assume booting on hart1 while
Opensbi and U-boot pick a hart at random.
This patch uses an SBI call to start the elfloader on hart1
if a different hart has been choses.
Credits go to Peter Chubb for the straw-man example.

Signed-off-by: Oliver Scott <Oliver.Scott@data61.csiro.au>