### PR TITLE
Revert "Fix issues with zeroing initial bss memory in elfloader"

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -188,10 +188,6 @@ if(KernelArchARM)
     list(APPEND files ${arm_files})
 endif()
 
-# Prevent any global variables to be placed in *COM* instead of .bss.
-# This causes linker errors for duplicate symbol definitions correctly
-# and allows the _bss and _bss_end symbols to capture all .bss variables properly.
-add_compile_options(-fno-common)
 if(ElfloaderImageEFI)
     # We cannot control where EFI loads the image and so we must make it relocatable
     add_compile_options(-fpic)

--- a/elfloader-tool/src/arch-arm/linker.lds
+++ b/elfloader-tool/src/arch-arm/linker.lds
@@ -29,10 +29,6 @@ INSERT BEFORE .text;
 SECTIONS
 {
     .bss : {
-        . = ALIGN(0x1000);
-        core_stack_alloc = .;
-        . = . + CONFIG_MAX_NUM_NODES * 1 << 12;
-        core_stack_alloc_end = .;
         _bss = .;
         *(.bss)
         _bss_end = .;

--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -24,6 +24,9 @@
 /* Maximum alignment we need to preserve when relocating (64K) */
 #define MAX_ALIGN_BITS (14)
 
+ALIGN(BIT(PAGE_BITS)) VISIBLE
+char core_stack_alloc[CONFIG_MAX_NUM_NODES][BIT(PAGE_BITS)];
+
 struct image_info kernel_info;
 struct image_info user_info;
 void *dtb;


### PR DESCRIPTION
This is failing to compile for EFI builds with -pie linking: https://sel4.systems/~bamboo/logs/SEL4-SEL4BENCH-SEL4BENCHBUILDGHSTATUS/41/SEL4-SEL4BENCH-CMAKEROCKPRO64AARCH64ID-41.log