### PR TITLE
elfloader: Put back core_stack_alloc for EFI

### DIFF
--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -24,6 +24,11 @@
 /* Maximum alignment we need to preserve when relocating (64K) */
 #define MAX_ALIGN_BITS (14)
 
+#ifdef CONFIG_IMAGE_EFI
+ALIGN(BIT(PAGE_BITS)) VISIBLE
+char core_stack_alloc[CONFIG_MAX_NUM_NODES][BIT(PAGE_BITS)];
+#endif
+
 struct image_info kernel_info;
 struct image_info user_info;
 void *dtb;


### PR DESCRIPTION
EFI configs don't call clear_bss (because their linker scripts don't
have a bss section) and as they use a different linker script that can't
as easily declare a core_stack_alloc symbol, we put it back here.

Signed-off-by: Kent McLeod <kent@kry10.com>