### PR TITLE
Reset CNTVOFF at boot for ODroid-C2

### DIFF
--- a/elfloader-tool/include/arch-arm/32/mode/arm_generic_timer.h
+++ b/elfloader-tool/include/arch-arm/32/mode/arm_generic_timer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <cpuid.h>
+#include <printf.h>
+
+/*
+ * Platforms that use the ARM generic timer in the kernel use the
+ * virtual counter when not in HYP mode. The offset value does not have
+ * a fixed reset value so could produce a random starting value for the
+ * virtual counter at boot.
+ *
+ * The offset must be explicitly set to zero in the elfloader before
+ * dropping to EL1 for the kernel.
+ */
+static inline void reset_cntvoff(void)
+{
+    if (is_hyp_mode()) {
+        /* Set CNTVOFF_El2 to zero */
+        asm volatile("mcrr p15, 4, %0, %0, c14" :: "r"(0));
+    } else {
+        printf("Not in hyp mode, cannot reset CNTVOFF_EL2\n");
+    }
+}

--- a/elfloader-tool/include/arch-arm/64/mode/arm_generic_timer.h
+++ b/elfloader-tool/include/arch-arm/64/mode/arm_generic_timer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <cpuid.h>
+#include <printf.h>
+
+/*
+ * Platforms that use the ARM generic timer in the kernel use the
+ * virtual counter when not in HYP mode. The offset value does not have
+ * a fixed reset value so could produce a random starting value for the
+ * virtual counter at boot.
+ *
+ * The offset must be explicitly set to zero in the elfloader before
+ * dropping to EL1 for the kernel.
+ */
+static inline void reset_cntvoff(void)
+{
+    if (is_hyp_mode()) {
+        /* Set CNTVOFF_El2 to zero */
+        asm volatile("msr cntvoff_el2, xzr");
+    } else {
+        printf("Not in hyp mode, cannot reset CNTVOFF_EL2\n");
+    }
+}

--- a/elfloader-tool/src/arch-arm/smp_boot.c
+++ b/elfloader-tool/src/arch-arm/smp_boot.c
@@ -25,6 +25,8 @@ void arm_disable_dcaches(void);
 extern void *dtb;
 extern uint32_t dtb_size;
 
+void __attribute__((weak)) non_boot_init(void) {}
+
 /* Entry point for all CPUs other than the initial. */
 void non_boot_main(void)
 {
@@ -37,6 +39,9 @@ void non_boot_main(void)
         cpu_idle();
 #endif
     }
+
+    /* Initialise any platform-specific per-core state */
+    non_boot_init();
 
 #ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
     if (is_hyp_mode()) {

--- a/elfloader-tool/src/plat/odroidc2/platform_init.c
+++ b/elfloader-tool/src/plat/odroidc2/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif


### PR DESCRIPTION
Any platform that is not configured with HYP but that uses the arm generic timer uses the virtual counter in the kernel rather than the physical counter. The virtual counter is offset from the physical counter by the virtual offset register, which has no fixed rest value and is only accessible to EL2 and EL3. This value needs to be reset by the bootloader while it is still running in EL2.

This is likely required for all platforms using the ARM generic timer, but currently only presents an issue for ODroid-C2 in our testing matrix.

Blocks https://github.com/seL4/seL4/pull/357