### PR TITLE
Reset CNTVOFF on all arm generic timer platforms

### DIFF
--- a/elfloader-tool/src/plat/apq8064/platform_init.c
+++ b/elfloader-tool/src/plat/apq8064/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/bcm2711/platform_init.c
+++ b/elfloader-tool/src/plat/bcm2711/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/bcm2837/platform_init.c
+++ b/elfloader-tool/src/plat/bcm2837/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/exynos5/platform_init.c
+++ b/elfloader-tool/src/plat/exynos5/platform_init.c
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <autoconf.h>
 #include <printf.h>
 #include <types.h>
 #include <cpuid.h>
+#include <mode/arm_generic_timer.h>
 
 #include <elfloader.h>
 
@@ -90,4 +92,15 @@ void platform_init(void)
         nsscode->cpu1_boot_reg = 0;
         smc(SMC_DISABLE_TRUSTZONE, 0, 0, 0);
     }
+
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
 }
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/fvp/platform_init.c
+++ b/elfloader-tool/src/plat/fvp/platform_init.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
 void platform_init(void)
 {
     /* On FVP, The MPIDR_EL1 changes to 0x80000000 after
@@ -17,4 +20,15 @@ void platform_init(void)
     asm volatile("mrs x0, mpidr_el1\n"
                  "msr tpidr_el0, x0\n"
                  ::: "x0");
+
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
 }
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/hikey/platform_init.c
+++ b/elfloader-tool/src/plat/hikey/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/imx7/platform_init.c
+++ b/elfloader-tool/src/plat/imx7/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/imx8m-evk/platform_init.c
+++ b/elfloader-tool/src/plat/imx8m-evk/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/qemu-arm-virt/platform_init.c
+++ b/elfloader-tool/src/plat/qemu-arm-virt/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/rockpro64/platform_init.c
+++ b/elfloader-tool/src/plat/rockpro64/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/tk1/platform_init.c
+++ b/elfloader-tool/src/plat/tk1/platform_init.c
@@ -5,6 +5,7 @@
  */
 
 #include <autoconf.h>
+#include <mode/arm_generic_timer.h>
 #include <elfloader/gen_config.h>
 #include <elfloader.h>
 #include <printf.h>
@@ -308,4 +309,14 @@ void platform_init(void)
     switch_to_mon_mode();
 #endif
 
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
 }
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/tx1/platform_init.c
+++ b/elfloader-tool/src/plat/tx1/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/tx2/platform_init.c
+++ b/elfloader-tool/src/plat/tx2/platform_init.c
@@ -5,6 +5,7 @@
  */
 
 #include <autoconf.h>
+#include <mode/arm_generic_timer.h>
 #include <elfloader.h>
 #include <printf.h>
 
@@ -83,5 +84,15 @@ static void enable_serr(void)
 void platform_init(void)
 {
     enable_serr();
+
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
 }
 
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    /* Reset the virtual offset for the platform timer to 0 */
+    reset_cntvoff();
+}
+#endif

--- a/elfloader-tool/src/plat/zynqmp/platform_init.c
+++ b/elfloader-tool/src/plat/zynqmp/platform_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif


### PR DESCRIPTION
When the kernel runs in EL1 on a platform with the arm generic timer the virtual counter is used. MCS can only correctly schedule in the first 3/8ths of representable time so must ensure that the offset is reset for the virtual timer while the bootloader is still in EL2 as EL1 cannot change the offset used to generate the virtual counter value.