### PR TITLE
CMakeLists: Fix image start addr generation call

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -272,10 +272,11 @@ if(NOT "${IMAGE_START_ADDR}" STREQUAL "")
 
     add_custom_command(
         OUTPUT "${PLATFORM_INFO_H}" "${IMAGE_START_ADDR_H}"
-        COMMAND echo "#pragma once\\n\/* no platform YAML file available */" >"${PLATFORM_INFO_H}"
         COMMAND
-            echo "#pragma once\\n#define IMAGE_START_ADDR ${IMAGE_START_ADDR}"
-            >"${IMAGE_START_ADDR_H}"
+            echo "#pragma once\\n\/* no platform YAML file available */" > "${PLATFORM_INFO_H}"
+        COMMAND
+            echo "#pragma once\\n#define IMAGE_START_ADDR ${IMAGE_START_ADDR}" >
+            "${IMAGE_START_ADDR_H}"
         VERBATIM
     )
 


### PR DESCRIPTION
The 'echo' calls was not generating the header files properly, adding in
whitespace between the '>' symbols allows CMake to properly parse the
arguments and invoke the calls correctly.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>