### PR TITLE
CMake: Add missing PLATFORM_SIFT variable

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -290,6 +290,7 @@ else()
     # due to the CMakeLists.txt file in the capDL repository also invoking a similar command
     # causing CMake to think that the first command with PLATFORM_SIFT is unnecessary.
     set(CMAKE_TOOL_HELPERS_DIR "${CMAKE_CURRENT_LIST_DIR}/../cmake-tool/helpers")
+    set(PLATFORM_SIFT "${CMAKE_TOOL_HELPERS_DIR}/platform_sift.py")
     set(ELF_SIFT "${CMAKE_TOOL_HELPERS_DIR}/elf_sift.py")
     set(SHOEHORN "${CMAKE_TOOL_HELPERS_DIR}/shoehorn.py")
     set(ARCHIVE_O "${CMAKE_CURRENT_BINARY_DIR}/archive.o")


### PR DESCRIPTION
The CMakeLists.txt file was missing the PLATFORM_SIFT variable.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>