### PR TITLE
riscv: Add clear_bss to crt0 if image is binary

### DIFF
--- a/elfloader-tool/src/arch-riscv/crt0.S
+++ b/elfloader-tool/src/arch-riscv/crt0.S
@@ -67,6 +67,7 @@ hsm_switch_hart:
   li a2, 0       // passed in a1 when new hart starts, this is the logical hart_id
   ecall
 
+  mv a0, t3 // Copy the ID of the HART again, since we've clobbered a0
   j secondary_harts
 
 _start1:

--- a/elfloader-tool/src/arch-riscv/crt0.S
+++ b/elfloader-tool/src/arch-riscv/crt0.S
@@ -30,8 +30,8 @@ _start:
   addi  gp, gp, %pcrel_lo(1b)
 .option pop
 
-/* a0 should have hart id, store it in temp so as not to clobber from HSM calls */
-  mv t3, a0
+/* a0 should have hart id, store it in s0 so as not to clobber from HSM calls */
+  mv s0, a0
 
 #ifdef CONFIG_IMAGE_BINARY
 /* Clear the BSS before we get to do anything more specific */
@@ -45,7 +45,7 @@ _start:
    or an extension-specific non-zero value if it is available.*/
 
   jal spi_probe_extension
-  mv a0, t3
+  mv a0, s0
   li s1, 1
   blt x1, s1, _start1
 
@@ -54,7 +54,7 @@ _start:
   li t2, 1
   amoadd.w t1, t2, (t1)
 
-  mv a0, t3
+  mv a0, s0
   li s0, CONFIG_FIRST_HART_ID
   beq  a0, s0, _start1
 
@@ -67,7 +67,7 @@ hsm_switch_hart:
   li a2, 0       // passed in a1 when new hart starts, this is the logical hart_id
   ecall
 
-  mv a0, t3 // Copy the ID of the HART again, since we've clobbered a0
+  mv a0, s0 // Copy the ID of the HART again, since we've clobbered a0
   j secondary_harts
 
 _start1:

--- a/elfloader-tool/src/arch-riscv/crt0.S
+++ b/elfloader-tool/src/arch-riscv/crt0.S
@@ -33,6 +33,11 @@ _start:
 /* a0 should have hart id, store it in temp so as not to clobber from HSM calls */
   mv t3, a0
 
+#ifdef CONFIG_IMAGE_BINARY
+/* Clear the BSS before we get to do anything more specific */
+  jal clear_bss
+#endif
+
 /* Check Heart State Management extension exists so we can use that to switch harts
    if we are not hart 1, otherwise rely on the legacy extension. */
 


### PR DESCRIPTION
Binary images do not have the luxury of having a proper loader load
the elfloader into memory correctly and zero out the BSS, so we have to
do it ourselves.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>