### PR TITLE
riscv: Use s1 instead of s0 for branch on _start1

### DIFF
--- a/elfloader-tool/src/arch-riscv/crt0.S
+++ b/elfloader-tool/src/arch-riscv/crt0.S
@@ -55,8 +55,8 @@ _start:
   amoadd.w t1, t2, (t1)
 
   mv a0, s0
-  li s0, CONFIG_FIRST_HART_ID
-  beq  a0, s0, _start1
+  li s1, CONFIG_FIRST_HART_ID
+  beq  a0, s1, _start1
 
 /* start hart 1*/
 hsm_switch_hart:


### PR DESCRIPTION
03627581 replaced t3 with s0 for holding the ID of the current HART,
there is a later load immediate instruction which clobbers s0, so we fix
the branch comparison to use s1 instead of s0.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>