### PR TITLE
CMake: pass PLATFORM for OpenSBI clean step

### DIFF
--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -113,7 +113,8 @@ function(DeclareRootserver rootservername)
                     OUTPUT "${OPENSBI_FW_PAYLOAD_ELF}"
                     COMMAND mkdir -p "${OPENSBI_BINARY_DIR}"
                     COMMAND
-                        make -s -C "${OPENSBI_PATH}" O="${OPENSBI_BINARY_DIR}" clean
+                        make -s -C "${OPENSBI_PATH}" O="${OPENSBI_BINARY_DIR}"
+                        PLATFORM="${KernelOpenSBIPlatform}" clean
                     COMMAND
                         ${CMAKE_OBJCOPY} -O binary "${elf_target_file}" "${OPENSBI_PLAYLOAD}"
                     COMMAND


### PR DESCRIPTION
Setting `PLATFORM` to a well defined value when running the clean step avoids running into conflicts where it happens to be defined as environment variable already with a value OpenSBI does not support.

See also https://github.com/riscv/opensbi/issues/217 that I have filed as potential issue there. 
