### PR TITLE
Sannum/rpi3 fixups

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -12,7 +12,7 @@ include_guard(GLOBAL)
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     set(
         binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64;cheshire"
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64;cheshire"
     )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "tx2;am335x")
@@ -23,9 +23,6 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         set(ElfloaderImage "efi" CACHE STRING "" FORCE)
     elseif(${kernel_platform} IN_LIST uimage_list)
         set(ElfloaderImage "uimage" CACHE STRING "" FORCE)
-        #rpi3
-    elseif(${kernel_platform} STREQUAL "bcm2837" AND ${kernel_sel4_arch} STREQUAL "aarch64")
-        set(ElfloaderImage "binary" CACHE STRING "" FORCE)
     elseif(${kernel_platform} IN_LIST binary_list)
         set(ElfloaderImage "binary" CACHE STRING "" FORCE)
     else()

--- a/elfloader-tool/src/arch-arm/64/crt0.S
+++ b/elfloader-tool/src/arch-arm/64/crt0.S
@@ -29,7 +29,7 @@ BEGIN_FUNC(_start)
     bl      fixup_image_base
     mov     x2, x0
     /* restore original arguments for next step */
-    ldp     x0, x1, [sp, #-16]!
+    ldp     x0, x1, [sp], #16
     /* fixup_image_base returns 1 if no need to move */
     cmp     x2, #1
     beq     1f

--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -116,7 +116,7 @@ void main(UNUSED void *arg)
     print_cpuid();
     printf("  paddr=[%p..%p]\n", _text, (uintptr_t)_end - 1);
 
-#if defined(CONFIG_IMAGE_UIMAGE)
+#if defined(CONFIG_IMAGE_UIMAGE) || defined(CONFIG_IMAGE_BINARY)
 
     /* U-Boot passes a DTB. Ancient bootloaders may pass atags. When booting via
      * bootelf argc is NULL.


### PR DESCRIPTION
A series of fixups for directly booting seL4 and seL4_test binary images on the Raspberry pi3 in both aarch32 and aarch64 modes as well as succesfully passing the dtb from the bootloader to the elfloader as this is currently not working.

The resulting sel4test-driver-image-arm-bcm2837 binary images should be directly bootable using the common bootloader.bin/start.elf and the following config.txt files:
```
enable_uart=1 
kernel=sel4test-driver-image-arm-bcm2837
kernel_address=0x[IMAGE_START_ADDR]
```
and
```
enable_uart=1 
kernel=sel4test-driver-image-arm-bcm2837
kernel_address=0x[IMAGE_START_ADDR]
arm_64bit=1
```
for aarch32 and aarch64 builds respectively.
Currently it seems the kernel_address must be manually configured to match the shoehorn generated IMAGE_START_ADDR which can be found with
```
aarch64-linux-gnu-objdump -t elfloader/elfloader | grep _text
```
as described in elfloader-tool/README.md

This also means that u-boot is not required as per https://docs.sel4.systems/Hardware/Rpi3.html.