### PR TITLE
elfloader: Use file(GENERATE) for static headers

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -269,15 +269,16 @@ set(PLATFORM_INFO_H "${PLATFORM_HEADER_DIR}/platform_info.h")
 set(IMAGE_START_ADDR_H "${PLATFORM_HEADER_DIR}/image_start_addr.h")
 
 if(NOT "${IMAGE_START_ADDR}" STREQUAL "")
-    add_custom_command(
-        OUTPUT "${PLATFORM_INFO_H}" "${IMAGE_START_ADDR_H}"
-        COMMAND
-            echo "#pragma once\\n\/* no platform YAML file available */" > "${PLATFORM_INFO_H}"
-        COMMAND
-            echo "#pragma once\\n#define IMAGE_START_ADDR ${IMAGE_START_ADDR}" >
-            "${IMAGE_START_ADDR_H}"
-        VERBATIM
-    )
+    # Generate static header files.  Their timestamps will change only if
+    # their contents have changed on subsequent CMake reruns.
+    file(GENERATE OUTPUT ${PLATFORM_INFO_H} CONTENT "
+#pragma once
+/* no platform YAML file available */
+")
+    file(GENERATE OUTPUT ${IMAGE_START_ADDR_H} CONTENT "
+#pragma once
+#define IMAGE_START_ADDR ${IMAGE_START_ADDR}
+")
 
 elseif(NOT DEFINED platform_yaml)
 


### PR DESCRIPTION
When generating header files, the "\\n" sequence doesn't generate a
newline character unless -e is given to echo.

Signed-off-by: Kent McLeod <kent@kry10.com>