### PR TITLE
cmake-tool: use numeric user IDs in cpio

### DIFF
--- a/cmake-tool/helpers/cpio.cmake
+++ b/cmake-tool/helpers/cpio.cmake
@@ -58,7 +58,7 @@ function(MakeCPIO output_name input_files)
         list(
             APPEND
                 commands
-                "bash;-c;cd `dirname ${file}` && mkdir -p temp_${output_name} && cd temp_${output_name} && cp -a ${file} . && touch -d @0 `basename ${file}` && echo `basename ${file}` | cpio --append ${cpio_reproducible_flag} --owner=root:root --quiet -o -H newc --file=${CMAKE_CURRENT_BINARY_DIR}/archive.${output_name}.cpio && rm `basename ${file}` && cd ../ && rmdir temp_${output_name};&&"
+                "bash;-c;cd `dirname ${file}` && mkdir -p temp_${output_name} && cd temp_${output_name} && cp -a ${file} . && touch -d @0 `basename ${file}` && echo `basename ${file}` | cpio --append ${cpio_reproducible_flag} --owner=+0:+0 --quiet -o -H newc --file=${CMAKE_CURRENT_BINARY_DIR}/archive.${output_name}.cpio && rm `basename ${file}` && cd ../ && rmdir temp_${output_name};&&"
         )
     endforeach()
     list(APPEND commands "true")


### PR DESCRIPTION
macOS does not have a group named `root`, so we use numeric user IDs to
get reproducible CPIO archives.

Signed-off-by: Matthew Brecknell <matt@kry10.com>