### PR TITLE
use proper types for parameters

### DIFF
--- a/elfloader-tool/include/arch-arm/elfloader.h
+++ b/elfloader-tool/include/arch-arm/elfloader.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -7,11 +8,16 @@
 
 #include <elfloader_common.h>
 
-typedef void (*init_arm_kernel_t)(paddr_t ui_p_reg_start,
-                                  paddr_t ui_p_reg_end,
-                                  uintptr_t pv_offset,
-                                  vaddr_t v_entry,
-                                  paddr_t dtb, uint32_t dtb_size);
+/* This is a low level binary interface, thus we do not preserve the type
+ * information here. All parameters are just register values (or stack values
+ * that are register-sized).
+ */
+typedef void (*init_arm_kernel_t)(word_t ui_p_reg_start,
+                                  word_t ui_p_reg_end,
+                                  word_t pv_offset,
+                                  word_t v_entry,
+                                  word_t dtb,
+                                  word_t dtb_size);
 
 
 /* Enable the mmu. */

--- a/elfloader-tool/include/arch-riscv/elfloader.h
+++ b/elfloader-tool/include/arch-riscv/elfloader.h
@@ -9,11 +9,16 @@
 #include <autoconf.h>
 #include <elfloader_common.h>
 
-typedef void (*init_riscv_kernel_t)(paddr_t ui_p_reg_start,
-                                    paddr_t ui_p_reg_end, int32_t pv_offset,
-                                    vaddr_t v_entry,
-                                    paddr_t dtb_addr_p,
-                                    uint32_t dtb_size
+/* This is a low level binary interface, thus we do not preserve the type
+ * information here. All parameters are just register values (or stack values
+ * that are register-sized).
+ */
+typedef void (*init_riscv_kernel_t)(word_t ui_p_reg_start,
+                                    word_t ui_p_reg_end,
+                                    word_t pv_offset,
+                                    word_t v_entry,
+                                    word_t dtb_addr_p,
+                                    word_t dtb_size
 #if CONFIG_MAX_NUM_NODES > 1
                                     ,
                                     word_t hart_id,

--- a/elfloader-tool/include/types.h
+++ b/elfloader-tool/include/types.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -114,14 +115,12 @@ typedef uintptr_t   size_t;
  * word_t is practically an alias for size_t/uintptr_t on the platforms we
  * support so far.
  */
-#if defined(__KERNEL_32__)
-typedef uint32_t    word_t;
-#define PRI_word    "u"
-#elif defined(__KERNEL_64__)
-typedef uint64_t    word_t;
-#define PRI_word    PRIu64
-#else
-#error expecting either __KERNEL_32__ or __KERNEL_64__ to be defined
-#endif
+typedef uintptr_t    word_t;
+
+/* printf() format specifiers for word_t */
+#define PRId_word   PRIdPTR
+#define PRIi_word   PRIiPTR
+#define PRIu_word   PRIuPTR
+#define PRIx_word   PRIxPTR
 
 #define BYTE_PER_WORD   sizeof(word_t)

--- a/elfloader-tool/include/types.h
+++ b/elfloader-tool/include/types.h
@@ -86,12 +86,14 @@ typedef uint64_t    uintmax_t;
 
 typedef int32_t         intptr_t;
 typedef uint32_t        uintptr_t;
+#define UINTPTR_MAX     UINT32_MAX
 #define _ptr_type_fmt   /* empty */
 
 #elif defined(__KERNEL_64__)
 
 typedef int64_t         intptr_t;
 typedef uint64_t        uintptr_t;
+#define UINTPTR_MAX     UINT64_MAX
 #define _ptr_type_fmt   _int64_type_fmt
 
 #else

--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -215,8 +215,11 @@ void continue_boot(int was_relocated)
     }
 
     ((init_arm_kernel_t)kernel_info.virt_entry)(user_info.phys_region_start,
-                                                user_info.phys_region_end, user_info.phys_virt_offset,
-                                                user_info.virt_entry, (paddr_t)dtb, dtb_size);
+                                                user_info.phys_region_end,
+                                                user_info.phys_virt_offset,
+                                                user_info.virt_entry,
+                                                (word_t)dtb,
+                                                dtb_size);
 
     /* We should never get here. */
     printf("ERROR: Kernel returned back to the ELF Loader\n");

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -278,7 +278,7 @@ void secondary_entry(int hart_id, int core_id)
                                                   user_info.phys_region_end,
                                                   user_info.phys_virt_offset,
                                                   user_info.virt_entry,
-                                                  (paddr_t) dtb,
+                                                  (paddr_t)dtb,
                                                   dtb_size,
                                                   hart_id,
                                                   core_id

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -243,7 +243,7 @@ static int run_elfloader(UNUSED int hart_id, void *bootloader_dtb)
                                                   user_info.phys_region_end,
                                                   user_info.phys_virt_offset,
                                                   user_info.virt_entry,
-                                                  (paddr_t)dtb,
+                                                  (word_t)dtb,
                                                   dtb_size
 #if CONFIG_MAX_NUM_NODES > 1
                                                   ,
@@ -278,7 +278,7 @@ void secondary_entry(int hart_id, int core_id)
                                                   user_info.phys_region_end,
                                                   user_info.phys_virt_offset,
                                                   user_info.virt_entry,
-                                                  (paddr_t)dtb,
+                                                  (word_t)dtb,
                                                   dtb_size,
                                                   hart_id,
                                                   core_id


### PR DESCRIPTION
Use word_t and sword_t to be architecture agnostic. 

This also requires a change in the kernel, see https://github.com/seL4/seL4/pull/494
