### PR TITLE
rootserver.cmake: remove use of config_option

### DIFF
--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -29,8 +29,8 @@ mark_as_advanced(TLS_ROOTSERVER)
 
 find_file(UIMAGE_TOOL make-uimage PATHS "${CMAKE_CURRENT_LIST_DIR}" CMAKE_FIND_ROOT_PATH_BOTH)
 mark_as_advanced(UIMAGE_TOOL)
-
-config_option(UseRiscVOpenSBI RISCV_OPENSBI "Use OpenSBI." DEFAULT ON DEPENDS "KernelArchRiscV")
+include(CMakeDependentOption)
+cmake_dependent_option(UseRiscVOpenSBI "Use OpenSBI." ON DEPENDS "KernelArchRiscV" OFF)
 
 if(UseRiscVOpenSBI)
     set(OPENSBI_PATH "${CMAKE_SOURCE_DIR}/tools/opensbi" CACHE STRING "OpenSBI Folder location")


### PR DESCRIPTION
config_option is primarily intended for generating a C header file with
config options. As no C header file is used in rootserver.cmake, it's
better to use a builtin CMake function that creates the CMake option as
expected.

Signed-off-by: Kent McLeod <kent@kry10.com>