### PR TITLE
cmake,cpio: Don't create folder at source location

### DIFF
--- a/cmake-tool/helpers/cpio.cmake
+++ b/cmake-tool/helpers/cpio.cmake
@@ -58,7 +58,7 @@ function(MakeCPIO output_name input_files)
         list(
             APPEND
                 commands
-                "bash;-c;cd `dirname ${file}` && mkdir -p temp_${output_name} && cd temp_${output_name} && cp -a ${file} . && touch -d @0 `basename ${file}` && echo `basename ${file}` | cpio --append ${cpio_reproducible_flag} --owner=+0:+0 --quiet -o -H newc --file=${CMAKE_CURRENT_BINARY_DIR}/archive.${output_name}.cpio && rm `basename ${file}` && cd ../ && rmdir temp_${output_name};&&"
+                "bash;-c; mkdir -p temp_${output_name} && cd temp_${output_name} && cp -a ${file} . && touch -d @0 `basename ${file}` && echo `basename ${file}` | cpio --append ${cpio_reproducible_flag} --owner=+0:+0 --quiet -o -H newc --file=${CMAKE_CURRENT_BINARY_DIR}/archive.${output_name}.cpio && rm `basename ${file}` && cd ../ && rmdir temp_${output_name};&&"
         )
     endforeach()
     list(APPEND commands "true")


### PR DESCRIPTION
When making a CPIO archive, the script tries to set the filetimes to 0
to allow reproducible builds. It needs to modify the input file to do
this and so creates a copy.  Now this copy is stored in a temp folder
that is relative to the destination path instead of input file source
path. This prevents race conditions when trying to create multiple CPIO
archives from the same source files, and also avoids complications
arising from trying to modify a different module's build directory after
it was built.

Signed-off-by: Kent McLeod <kent@kry10.com>