### PR TITLE
rootserver.cmake: Find readelf in old CMake

### DIFF
--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -174,6 +174,18 @@ function(DeclareRootserver rootservername)
                 )
             endif()
 
+            # Older versions of CMake don't look for readelf when initializing other binutils tools.
+            if(NOT CMAKE_READELF)
+                find_program(CMAKE_READELF NAMES ${CROSS_COMPILER_PREFIX}readelf)
+                if(NOT CMAKE_READELF)
+                    message(
+                        FATAL_ERROR
+                            "Could not find a valid readelf program: ${CROSS_COMPILER_PREFIX}readelf.
+                        ElfloaderImage type 'uimage' cannot be built."
+                    )
+                endif()
+            endif()
+
             add_custom_command(
                 OUTPUT "${IMAGE_NAME}"
                 COMMAND


### PR DESCRIPTION
In older CMake versions, readelf isn't automatically detected by CMake
and so may need to be found manually.

Signed-off-by: Kent McLeod <kent@kry10.com>