### PR TITLE
Change zynqmp to use ELF executables

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.8.2)
 include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
-    set(binary_list "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;zynqmp;imx8mm-evk;hifive;tqma8xqp1gb")
+    set(binary_list "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;hifive;tqma8xqp1gb")
     set(efi_list "tk1;rockpro64")
     set(uimage_list "tx2;am335x")
     if(


### PR DESCRIPTION
If executables are loaded as ELF instead of Binary, U-Boot can detect
whether to invoke them in 32 or 64 bit mode.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>