### PR TITLE
elfloader: pass KernelSel4Arch to python scripts

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -337,6 +337,7 @@ if(DEFINED KernelDTBPath)
             --hardware-config "${config_file}"
             --hardware-schema "${schema_file}"
             --dtb "${KernelDTBPath}"
+            --sel4arch "${KernelSel4Arch}"
         VERBATIM
         DEPENDS ${KernelDTBPath} ${config_file} ${schema_file}
     )


### PR DESCRIPTION
The parameter is optional and defaults to 'arm', which is a semantic error when building RISC-V targets. This does not cause any issues so far, because the value is mostly unused.

This change requires https://github.com/seL4/seL4/pull/642

Test with seL4/seL4#642
