### PR TITLE
correct the print dtb address

### DIFF
--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -133,7 +133,7 @@ void main(UNUSED void *arg)
 #endif
 
     if (bootloader_dtb) {
-        printf("  dtb=%p\n", dtb);
+        printf("  dtb=%p\n", bootloader_dtb);
     } else {
         printf("No DTB passed in from boot loader.\n");
     }


### PR DESCRIPTION
When use bootloader DTB, it always print 0 as the DTB addrss, the print
usage wrong variable.

Signed-off-by: Lihua Zhao <lihuazhao.cn@gmail.com>