### PR TITLE
elfloader/risc-v: minor SBI wrapper code cleanup

### DIFF
--- a/elfloader-tool/include/arch-riscv/sbi.h
+++ b/elfloader-tool/include/arch-riscv/sbi.h
@@ -38,7 +38,7 @@
     register uintptr_t a1 asm ("a1") = (uintptr_t)(arg1);   \
     register uintptr_t a2 asm ("a2") = (uintptr_t)(arg2);   \
     register uintptr_t a7 asm ("a6") = (uintptr_t)(which);  \
-    register uintptr_t a6 asm ("a7") = (uintptr_t)extension; \
+    register uintptr_t a6 asm ("a7") = (uintptr_t)(extension); \
     asm volatile ("ecall"                   \
               : "+r" (a0)               \
               : "r" (a1), "r" (a2), "r" (a7), "r" (a6)      \

--- a/elfloader-tool/include/arch-riscv/sbi.h
+++ b/elfloader-tool/include/arch-riscv/sbi.h
@@ -37,11 +37,11 @@
     register uintptr_t a0 asm ("a0") = (uintptr_t)(arg0);   \
     register uintptr_t a1 asm ("a1") = (uintptr_t)(arg1);   \
     register uintptr_t a2 asm ("a2") = (uintptr_t)(arg2);   \
-    register uintptr_t a7 asm ("a6") = (uintptr_t)(which);  \
-    register uintptr_t a6 asm ("a7") = (uintptr_t)(extension); \
+    register uintptr_t a6 asm ("a6") = (uintptr_t)(which);  \
+    register uintptr_t a7 asm ("a7") = (uintptr_t)(extension); \
     asm volatile ("ecall"                   \
               : "+r" (a0)               \
-              : "r" (a1), "r" (a2), "r" (a7), "r" (a6)      \
+              : "r" (a1), "r" (a2), "r" (a6), "r" (a7)      \
               : "memory");              \
     a0;                         \
 })


### PR DESCRIPTION
elfloader/risc-v: add missing brackets (it's a macro, so brackets are required to ensure it's an atom)
elfloader/risc-v: fix register naming