### PR TITLE
Add --dry-run to simulate.py

### DIFF
--- a/cmake-tool/simulate_scripts/simulate.py
+++ b/cmake-tool/simulate_scripts/simulate.py
@@ -35,6 +35,8 @@ def parse_args():
                         help="Kernel file to pass onto QEMU", default="@QEMU_SIM_KERNEL_FILE@")
     parser.add_argument('-i', '--initrd', dest='qemu_sim_initrd_file', type=str,
                         help="Initrd file to pass onto QEMU", default="@QEMU_SIM_INITRD_FILE@")
+    parser.add_argument('-n', '--dry-run', dest='dry_run', action='store_true',
+                        help="Output qemu command, but do not run it")
     parser.add_argument('--extra-qemu-args', dest='qemu_sim_extra_args', type=str,
                         help="Additional arguments to pass onto QEMU", default="@QEMU_SIM_EXTRA_ARGS@")
     parser.add_argument('--extra-cpu-opts', dest='qemu_sim_extra_cpu_opts', type=str,
@@ -80,23 +82,26 @@ if __name__ == "__main__":
                                   qemu_gdbserver_command]
     qemu_simulate_command = " ".join(qemu_simulate_command_opts)
 
-    notice(qemu_simulate_command)
+    notice('QEMU Command: ' + qemu_simulate_command)
 
     if qemu_gdbserver_command != "":
-        notice('waiting for GDB on port 1234...')
+        notice('GDB Command: ' + qemu_gdbserver_command)
+        if not args.dry_run:
+            notice('waiting for GDB on port 1234...')
 
-    qemu_status = subprocess.call(qemu_simulate_command, shell=True)
+    if not args.dry_run:
+        qemu_status = subprocess.call(qemu_simulate_command, shell=True)
 
-    if qemu_status != 0:
-        delay = 5  # in seconds
-        # Force a newline onto the output stream.
-        sys.stderr.write('\n')
-        msg = "QEMU failed; resetting terminal in {d} seconds".format(d=delay) \
-            + "--interrupt to abort\n"
-        notice(msg)
-    else:
-        delay = 2  # in seconds
+        if qemu_status != 0:
+            delay = 5  # in seconds
+            # Force a newline onto the output stream.
+            sys.stderr.write('\n')
+            msg = "QEMU failed; resetting terminal in {d} seconds".format(d=delay) \
+                + "--interrupt to abort\n"
+            notice(msg)
+        else:
+            delay = 2  # in seconds
 
-    time.sleep(delay)
+        time.sleep(delay)
 
-    subprocess.call("tput reset", shell=True)
+        subprocess.call("tput reset", shell=True)


### PR DESCRIPTION
Previously, it's impossible to read the QEMU command because QEMU switch to another screen when run.

This option let me read the command to run QEMU without running it.