### PR TITLE
Add support for the Avnet MaaXBoard (seL4_tools)

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -1,6 +1,7 @@
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 # Copyright 2020, HENSOLDT Cyber GmbH
+# Copyright 2022, Capgemini Engineering
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -35,9 +36,9 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         set(ElfloaderMode "hypervisor" CACHE STRING "" FORCE)
         set(ElfloaderMonitorHook ON CACHE BOOL "" FORCE)
     endif()
-    if((KernelPlatformImx8mm-evk OR KernelPlatformImx8mq-evk) AND KernelSel4ArchAarch32)
+    if((KernelPlatformImx8mm-evk OR KernelPlatImx8mq) AND KernelSel4ArchAarch32)
         set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
-        # This applies to imx8mm and imx8mq when in aarch32 configuration
+        # This applies to imx8mm, imx8mq (EVK and MaaXBoard) when in aarch32 configuration
         # It should be possible to use a uimage format but when tried nothing
         # runs after uboot.
         set(IMAGE_START_ADDR 0x41000000 CACHE INTERNAL "" FORCE)

--- a/elfloader-tool/src/plat/maaxboard/platform_init.c
+++ b/elfloader-tool/src/plat/maaxboard/platform_init.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, Capgemini Engineering
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <autoconf.h>
+#include <mode/arm_generic_timer.h>
+
+/* Reset the virtual offset for the platform timer to 0 */
+void platform_init(void)
+{
+    reset_cntvoff();
+}
+
+#if CONFIG_MAX_NUM_NODES > 1
+void non_boot_init(void)
+{
+    reset_cntvoff();
+}
+#endif


### PR DESCRIPTION
This pull request is a call for feedback and comment on an initial implementation for supporting seL4 on the Avnet MaaXBoard, with the intention of the changes below being merged back to the main seL4_tools repository. This pull request is dependent on another pull request which provides the core support for the MaaXBoard in the seL4 repository; this can be found [here](https://github.com/seL4/seL4/pull/829).

This pull request contains the following changes:
* The creation of a platform_init file for the MaaXBoard, performing the necessary resets for initialising the board.
* Renaming of the specific `KernelPlatformImx8mq-evk` platform from `cmake-tool/helpers/application_settings.cmake`, creating a common `KernelPlatformImx8mq` platform, which can be used by both the imx8mq-evk evaluation board and the Avnet MaaXBoard.

seL4test has been tested with these changes only on the MaaXBoard itself, but all tests run as expected resulting in a `All is well in the universe` message. No other platforms have been tested.

Test with: seL4/seL4#829, seL4/util_libs#129