### PR TITLE
elfloader/arm64: add "write-through" support

### DIFF
--- a/elfloader-tool/include/arch-arm/64/mode/assembler.h
+++ b/elfloader-tool/include/arch-arm/64/mode/assembler.h
@@ -64,6 +64,7 @@
 #define MT_DEVICE_GRE     2
 #define MT_NORMAL_NC      3
 #define MT_NORMAL         4
+#define MT_NORMAL_WT      5
 #define MAIR(_attr, _mt)  ((_attr) << ((_mt) * 8))
 
 .macro enable_mmu sctlr tmp

--- a/elfloader-tool/src/arch-arm/armv/armv8-a/64/mmu-hyp.S
+++ b/elfloader-tool/src/arch-arm/armv/armv8-a/64/mmu-hyp.S
@@ -86,12 +86,14 @@ BEGIN_FUNC(arm_enable_hyp_mmu)
      *   DEVICE_GRE         010     00001100
      *   NORMAL_NC          011     01000100
      *   NORMAL             100     11111111
+     *   NORMAL_WT          101     10101010
      */
     ldr     x5, =MAIR(0x00, MT_DEVICE_nGnRnE) | \
                  MAIR(0x04, MT_DEVICE_nGnRE) | \
                  MAIR(0x0c, MT_DEVICE_GRE) | \
                  MAIR(0x44, MT_NORMAL_NC) | \
-                 MAIR(0xff, MT_NORMAL)
+                 MAIR(0xff, MT_NORMAL) | \
+                 MAIR(0xaa, MT_NORMAL_WT)
     msr     mair_el2, x5
     ldr     x8, =TCR_T0SZ(48) | TCR_IRGN0_WBWC | TCR_ORGN0_WBWC | TCR_SH0_ISH | TCR_TG0_4K | TCR_PS | TCR_EL2_RES1
     msr     tcr_el2, x8

--- a/elfloader-tool/src/arch-arm/armv/armv8-a/64/mmu.S
+++ b/elfloader-tool/src/arch-arm/armv/armv8-a/64/mmu.S
@@ -60,12 +60,14 @@ BEGIN_FUNC(arm_enable_mmu)
      *   DEVICE_GRE         010     00001100
      *   NORMAL_NC          011     01000100
      *   NORMAL             100     11111111
+     *   NORMAL_WT          101     10101010
      */
     ldr     x5, =MAIR(0x00, MT_DEVICE_nGnRnE) | \
                  MAIR(0x04, MT_DEVICE_nGnRE) | \
                  MAIR(0x0c, MT_DEVICE_GRE) | \
                  MAIR(0x44, MT_NORMAL_NC) | \
-                 MAIR(0xff, MT_NORMAL)
+                 MAIR(0xff, MT_NORMAL) | \
+                 MAIR(0xaa, MT_NORMAL_WT)
     msr     mair_el1, x5
 
     ldr     x10, =TCR_TxSZ(48) | TCR_IRGN_WBWA | TCR_ORGN_WBWA | TCR_TG0_4K | TCR_TG1_4K | TCR_ASID16 | TCR_ISH


### PR DESCRIPTION
Memory region type: "Normal memory, write-through" was added.

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>

Test with: seL4/seL4#834