### PR TITLE
CMake: warn if ElfloaderImage is missing

### DIFF
--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -153,6 +153,11 @@ function(DeclareRootserver rootservername)
                 set(elf_target_file "${OPENSBI_SYSTEM_IMAGE_ELF}")
             endif()
         endif()
+
+        if(NOT ElfloaderImage)
+            # Seems the Elfloader CMake project was not included?
+            message(FATAL_ERROR "ElfloaderImage is not set.")
+        endif()
         set(binary_efi_list "binary;efi")
         if(${ElfloaderImage} IN_LIST binary_efi_list)
             # If not an elf we construct an intermediate rule to do an objcopy to binary

--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -13,6 +13,10 @@ if(KernelArchX86)
     return()
 endif()
 
+if(NOT KERNEL_FLAGS_PATH)
+    # Seems the seL4 kernel CMake project was not included?
+    message(FATAL_ERROR "KERNEL_FLAGS_PATH is not set.")
+endif()
 include(${KERNEL_FLAGS_PATH})
 include(cpio)
 


### PR DESCRIPTION
When using a customized build system, `ElfloaderImage` could not be set due to some usage error. Printing a user friendly warning message instead of running into the rather strange CMake error message
```
CMake Error at /host/OS-SDK/pkg/sdk-sel4-camkes/tools/seL4/cmake-tool/helpers/rootserver.cmake:161 (if):
  if given arguments:

    "IN_LIST" "binary_efi_list"

  Unknown arguments specified
```