### PR TITLE
shoehorn: handle missing kernel.elf

### DIFF
--- a/cmake-tool/helpers/shoehorn.py
+++ b/cmake-tool/helpers/shoehorn.py
@@ -142,6 +142,7 @@ sufficiently-large memory region.
     rootservers = []
     is_dtb_present = False
     is_good_fit = False
+    kernel_elf = None
 
     with libarchive.memory_reader(get_cpio(image)) as archive:
         for entry in archive:
@@ -159,6 +160,9 @@ sufficiently-large memory region.
                 notice('skipping checkum entry "{}"'.format(name))
             else:
                 rootservers.append(get_bytes(entry))
+
+    if not kernel_elf:
+        die('missing kernel.elf')
 
     # Enumerate the regions as we encounter them for diagnostic purposes.
     region_counter = -1


### PR DESCRIPTION
Improve error handling. Due to some other error I ran into a situation where `kernel.elf` was missing in the CPIO archive and `shoehorn` gave a rather odd error message that `kernel_elf` is used without being defined. Now the tool clearly says that `kernel.elf` is missing in the CPIO archive.