### PR TITLE
cmake_tool: add zynqmp to platform_strings

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -162,6 +162,7 @@ function(correct_platform_strings)
         "bcm2711:rpi4"
         "exynos5:exynos5250,exynos5410,exynos5422"
         "am335x:am335x-boneblack,am335x-boneblue,am335x-bone"
+        "zynqmp:zcu102,ultra96,ultra96v2"
         "-KernelSel4Arch"
         "pc99:x86_64,ia32"
     )


### PR DESCRIPTION
Without adding the zynqmp subplatforms (zcu102, ultra96, ultra96v2), sel4test can only be compiled for the generic zynqmp platform. While this is compatible with the ZCU102, the Ultra96 platforms use a different serial port, so the sel4test logs would be unreadable.

This commit allows sel4test to be compiled with -DPLATFORM=ultra96 and -DPLATFORM=ultra96v2.

Signed-off-by: Chris Guikema <chrisguikema@dornerworks.com>