### PR TITLE
gitlint: enable regex-style-search explicitly

### DIFF
--- a/misc/.gitlint
+++ b/misc/.gitlint
@@ -14,6 +14,14 @@ ignore-fixup-commits=false
 # By default gitlint will ignore squash commits. Set to 'false' to disable.
 ignore-squash-commits=false
 
+# So far, gitlint uses Python's `re.match()` (match from start) by default, but
+# it will change to use the more generic `re.search()` (match anywhere) in the
+# future. With 'regex-style-search' the behaviour can be controlled. Since we
+# prefer `re.search()` anyway, the new behavior is enabled. For more details
+# see also https://jorisroovers.com/gitlint/configuration/#regex-style-search.
+regex-style-search=true
+
+
 [title-max-length]
 line-length=50
 


### PR DESCRIPTION
Setting `regex-style-search=true` avoids a warning. 
```
WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to
'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly.
To remove this warning, set general.regex-style-search=True. 
More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
```
So far, gitlint uses Python's `re.match()` (match from start) by default, but it will change to use the more generic `re.search()` (match anywhere) in the future. Since we prefer `re.search()`, the new behavior is enabled  explicitly.  For more details see also
https://jorisroovers.com/gitlint/configuration/#regex-style-search.
