### PR TITLE
Reduce fudge factor from shoehorn and strip elf files before loading

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -57,6 +57,13 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         endif()
         set(IMAGE_START_ADDR 0x10000000 CACHE INTERNAL "" FORCE)
     endif()
+    if(KernelPlatformSpike OR KernelPlatformQEMURiscVVirt)
+        # Spike/qemu loads elfloader to either 0x80200000 or 0x80400000
+        # But the RISC-V kernel is currently loaded to a different
+        # address than what's modelled by the shoehorn.py tool.
+        # So force the start address to one that works.
+        set(IMAGE_START_ADDR 0x81000000 CACHE INTERNAL "" FORCE)
+    endif()
     if(KernelPlatformStar64)
         set(IMAGE_START_ADDR 0x60000000 CACHE INTERNAL "" FORCE)
     endif()

--- a/cmake-tool/helpers/shoehorn.py
+++ b/cmake-tool/helpers/shoehorn.py
@@ -206,9 +206,11 @@ sufficiently-large memory region.
                 marker += elf_sift.get_memory_usage(elf, align=True)
                 debug_marker_set(marker, 'end of rootserver')
 
-            # Note: sel4test_driver eats (almost) 4 more MiB than it claims to.
-            # Fixing this is JIRA SELFOUR-2335.
-            fudge_factor = 4 * 1024 * 1024
+            # Note: To handle the case where the elfloader is initially loaded to
+            # the start of the available memory region, we add an aditional overhead
+            # factor to account for the size of the elfloader program itself so that
+            # it won't need to move over the top of itself.
+            fudge_factor = 128 * 1024
             marker += elf_sift.get_aligned_size(fudge_factor)
             debug_marker_set(marker, 'end of (aligned) fudge factor')
 

--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -250,11 +250,28 @@ endif()
 list(SORT files)
 
 set(cpio_files "")
-list(APPEND cpio_files "$<TARGET_FILE:kernel.elf>")
+add_custom_command(
+    OUTPUT "kernel.elf"
+    COMMAND
+        ${CMAKE_STRIP} $<TARGET_FILE:kernel.elf> -o ${CMAKE_CURRENT_BINARY_DIR}/kernel.elf
+    VERBATIM
+    DEPENDS "$<TARGET_FILE:kernel.elf>"
+)
+list(APPEND cpio_files "${CMAKE_CURRENT_BINARY_DIR}/kernel.elf")
+
+
+
 if(ElfloaderIncludeDtb)
     list(APPEND cpio_files "${KernelDTBPath}")
 endif()
-list(APPEND cpio_files "$<TARGET_PROPERTY:rootserver_image,ROOTSERVER_IMAGE>")
+add_custom_command(
+    OUTPUT "rootserver"
+    COMMAND
+        ${CMAKE_STRIP} $<TARGET_PROPERTY:rootserver_image,ROOTSERVER_IMAGE> -o ${CMAKE_CURRENT_BINARY_DIR}/rootserver
+    VERBATIM
+    DEPENDS "$<TARGET_PROPERTY:rootserver_image,ROOTSERVER_IMAGE>"
+)
+list(APPEND cpio_files "${CMAKE_CURRENT_BINARY_DIR}/rootserver")
 if(NOT ${ElfloaderHashInstructions} STREQUAL "hash_none")
     set(hash_command "")
     if(ElfloaderHashSHA)


### PR DESCRIPTION
Correct the calculated memory needed to load an elf image. Using only
the p_memsz value ignores gaps between segments; instead calculate the
first+last addresses using p_vaddr & p_memsz.

As get_memory_usage in elf_sift.py now can calculate correct memory
usage from a list of ELF segments, a more accurate upper bound on
memory usage for the loaded apps is possible and the old fudge
factor is no longer needed.

Thanks to @sleffler for the patch.