### PR TITLE
Fix `UseRiscVOpenSBI` CMake option

### DIFF
--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -30,7 +30,7 @@ mark_as_advanced(TLS_ROOTSERVER)
 find_file(UIMAGE_TOOL make-uimage PATHS "${CMAKE_CURRENT_LIST_DIR}" CMAKE_FIND_ROOT_PATH_BOTH)
 mark_as_advanced(UIMAGE_TOOL)
 include(CMakeDependentOption)
-cmake_dependent_option(UseRiscVOpenSBI "Use OpenSBI." ON DEPENDS "KernelArchRiscV" OFF)
+cmake_dependent_option(UseRiscVOpenSBI "Use OpenSBI." ON "KernelArchRiscV" OFF)
 
 if(UseRiscVOpenSBI)
     set(OPENSBI_PATH "${CMAKE_SOURCE_DIR}/tools/opensbi" CACHE STRING "OpenSBI Folder location")


### PR DESCRIPTION
Closes https://github.com/seL4/seL4_tools/issues/164. Perhaps we should use `config_option` to be consistent with other CMake options? Happy to change the patch to use that instead, I don't know enough about CMake to know which is better.