### PR TITLE
Fix RISC-V compilation with recent GCC

### DIFF
--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -118,11 +118,11 @@ function(DeclareRootserver rootservername)
                         CMAKE_ASM_COMPILER_ID STREQUAL "GNU"
                         AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "11.3"
                     )
-                       # Manually enable Zicsr and Zifencei extensions
-                       # This became necessary due to a change in the
-                       # default ISA version in GNU binutils 2.38 which
-                       # is the default binutils version shipped with GCC 11.3
-                       string(APPEND OPENSBI_PLAT_ISA "_zicsr_zifencei")
+                        # Manually enable Zicsr and Zifencei extensions
+                        # This became necessary due to a change in the
+                        # default ISA version in GNU binutils 2.38 which
+                        # is the default binutils version shipped with GCC 11.3
+                        string(APPEND OPENSBI_PLAT_ISA "_zicsr_zifencei")
                     endif()
                 endif()
 

--- a/cmake-tool/helpers/rootserver.cmake
+++ b/cmake-tool/helpers/rootserver.cmake
@@ -111,6 +111,19 @@ function(DeclareRootserver rootservername)
 
                 if(NOT OPENSBI_PLAT_ISA)
                     set(OPENSBI_PLAT_ISA "rv${OPENSBI_PLAT_XLEN}imafdc")
+
+                    # Determine if GNU toolchain is used and if yes,
+                    # whether GCC version >= 11.3 (implies binutils version >= 2.38)
+                    if(
+                        CMAKE_ASM_COMPILER_ID STREQUAL "GNU"
+                        AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "11.3"
+                    )
+                       # Manually enable Zicsr and Zifencei extensions
+                       # This became necessary due to a change in the
+                       # default ISA version in GNU binutils 2.38 which
+                       # is the default binutils version shipped with GCC 11.3
+                       string(APPEND OPENSBI_PLAT_ISA "_zicsr_zifencei")
+                    endif()
                 endif()
 
                 if(NOT OPENSBI_PLAT_ABI)


### PR DESCRIPTION
Default args for gcc have changed; we need to fix the args given to the compiler.