### PR TITLE
elfloader: Add ElfloaderPrecompile option

### DIFF
--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -95,6 +95,14 @@ config_option(
     DEPENDS KernelArchArmV8a
 )
 
+config_option(
+    ElfloaderPrecompile ELFLOADER_PRECOMPILE
+    "Precompile the elfloader but only partially link. Produces elfloader.o and a linker script.
+     Final linking can be done later with the CPIO archive."
+    DEFAULT OFF
+    DEPENDS "NOT ElfloaderImageEFI"
+)
+
 add_config_library(elfloader "${configure_string}")
 
 add_compile_options(-D_XOPEN_SOURCE=700 -ffreestanding -Wall -Werror -W -Wextra)
@@ -370,7 +378,19 @@ add_custom_command(
 )
 add_custom_target(elfloader_linker DEPENDS linker.lds_pp)
 
-add_executable(elfloader EXCLUDE_FROM_ALL ${files} archive.o)
+if(ElfloaderPrecompile)
+    # Create an object library instead of an executable
+    # Then this below a custom target is added that prelinks the
+    # objects from this library and the cpio library into a single
+    # object file that's only missing the cpio archive symbol.
+    # Later the cpio archive symbol can be linked with elfloader.o
+    # to create an elfloader image without needing to import all of
+    # the build tools required to build the rest of the elfloader.
+    add_library(elfloader OBJECT EXCLUDE_FROM_ALL ${files})
+else()
+    add_executable(elfloader EXCLUDE_FROM_ALL ${files} archive.o)
+endif()
+
 if(ElfloaderImageEFI)
     set_property(TARGET elfloader APPEND_STRING PROPERTY LINK_FLAGS " -pie ")
     set_target_properties(elfloader PROPERTIES LINK_DEPENDS ${linkerScript})
@@ -383,6 +403,20 @@ if(ElfloaderImageEFI)
             # EFI_SUBSYSTEM=0xa indicates that we're building an EFI application.
             " -Wl,-T ${linkerScript} -nostdlib -shared -Wl,-Bsymbolic,--defsym=EFI_SUBSYSTEM=0xa -Wl,--build-id=none"
     )
+elseif(ElfloaderPrecompile)
+    add_custom_command(
+        OUTPUT elfloader.o
+        COMMAND
+            ${CMAKE_LINKER} -r $<TARGET_OBJECTS:elfloader> $<TARGET_OBJECTS:cpio> -o elfloader.o
+        DEPENDS $<TARGET_OBJECTS:elfloader> $<TARGET_OBJECTS:cpio> COMMAND_EXPAND_LISTS
+    )
+
+    add_custom_target(
+        elfloader_precompile
+        DEPENDS elfloader.o ${CMAKE_CURRENT_BINARY_DIR}/linker.lds_pp
+    )
+    add_dependencies(elfloader_precompile elfloader_linker)
+
 else()
     set_target_properties(
         elfloader


### PR DESCRIPTION
This option generates an intermediate build file, elfloader.o, that can be combined in a separate build step with an archive.o containing the cpio archive with the kernel and rootserver images to load. This enables the elfloader to be installed by copying the elfloader.o and generated linker file to an install location and a future build step can link with a supplied archive.o into a bootable elfloader image using something like:
  aarch64-unknown-linux-gnu-gcc -march=armv8-a elfloader.o archive.o \
    -o elfloader -Wl,-T linker.lds_pp -nostdlib -static -lgcc