### PR TITLE
Rocket chip fix

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -10,7 +10,10 @@ cmake_minimum_required(VERSION 3.8.2)
 include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
-    set(binary_list "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;hifive;tqma8xqp1gb;bcm2711")
+    set(
+        binary_list
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;hifive;tqma8xqp1gb;bcm2711;rocketchip"
+    )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "tx2;am335x")
     if(

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -159,6 +159,8 @@ function(correct_platform_strings)
         # and leave all further setup to the architecture/platform specific
         # configuration to <sel4 kernel>/src/plat/*/config.cmake
         #
+        "-KernelRiscVPlatform"
+        "rocketchip:rocketchip-base,rocketchip-zcu102"
         "-KernelARMPlatform"
         "imx6:sabre,wandq,nitrogen6sx"
         "bcm2837:rpi3"


### PR DESCRIPTION
Added `-KernelRiscVPlatform` as a platform for `platform_aliases` and specified the aliases for `rocketchip`. This allows specific implementations of the rocket chip to be specified via `-DPLATFORM` with the `init-script.sh`.

Also changed the rocket chip default build to be a binary instead of an elf. We currently suggest loading via jtag, which requires a binary file.

Helps fix issue: https://github.com/seL4/seL4/issues/1078