### PR TITLE
CI: bring back compiler to matrix

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         # There is no "rv32imac" hardware yet.
         march: [armv7a, armv8a, nehalem, rv64imac]
+        compiler: [gcc, clang]
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4test-hw@master


### PR DESCRIPTION
This was deleted by accident in commit 75fc8008 from PR https://github.com/seL4/seL4_tools/pull/183