### PR TITLE
morello: Add FVP and SoC platforms to the EFI list

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -14,7 +14,7 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         binary_list
         "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;hifive;tqma8xqp1gb;bcm2711;rocketchip"
     )
-    set(efi_list "tk1;rockpro64;quartz64")
+    set(efi_list "tk1;rockpro64;quartz64;morello-fvp;morello-soc")
     set(uimage_list "tx2;am335x")
     if(
         ${kernel_platform} IN_LIST efi_list


### PR DESCRIPTION
morello-fvp and morello-soc are loaded by UEFI.