### PR TITLE
github: bump actions to node20

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -44,7 +44,7 @@ jobs:
         compiler: ${{ matrix.compiler }}
         sha: ${{ github.event.pull_request.head.sha }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
@@ -82,7 +82,7 @@ jobs:
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run


### PR DESCRIPTION
GitHub has started issuing warnings for node16 actions.