### PR TITLE
elfloader: initialise stack allocated struct

### DIFF
--- a/elfloader-tool/src/plat/tx2/platform_init.c
+++ b/elfloader-tool/src/plat/tx2/platform_init.c
@@ -61,7 +61,7 @@ static __attribute__((noinline)) int send_smc(uint8_t func, struct mce_regs *reg
 
 static void tegra_mce_write_uncore_mca(mca_cmd_t cmd, uint64_t data, uint32_t *err)
 {
-    struct mce_regs regs;
+    struct mce_regs regs = {0};
     regs.args[0] = cmd.data;
     regs.args[1] = data;
     send_smc(13, &regs);


### PR DESCRIPTION
Only results in a compilation error on newer GCC versions.

What confuses me though is this only happens for me in sel4bench, but not sel4test. I believe I'm using the same compiler in both projects, but se4lbench results in a unitialised warning that is treated as a compile error. sel4test does not even print the warning?