### PR TITLE
misc: remove deprecated astyle option

### DIFF
--- a/misc/astylerc
+++ b/misc/astylerc
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-max-instatement-indent=120
 style=otbs
 pad-header
 indent=spaces=4


### PR DESCRIPTION
Release 3.0 of astyle replaced this option with
'max-continuation-indent'. The replaced option is already in the astylerc so we just need to remove the option here.

Further information can be found in the release notes: https://astyle.sourceforge.net/news.html