### PR TITLE
misc: check that astyle exists

### DIFF
--- a/misc/style-c.sh
+++ b/misc/style-c.sh
@@ -4,6 +4,13 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
+set -e
+
+if ! command -v astyle >/dev/null 2>&1
+then
+    echo "astyle could not be found, it must be available to run the script."
+    exit 1
+fi
 
 # Format (in place) a list of files as C code.
 astyle --options="${0%/*}/astylerc" "$@"


### PR DESCRIPTION
We use the seL4 style check for sDDF and most people who try to run the style check offline end up running into weird issues since they don't have it installed.
