### PR TITLE
Shift 32-bit image start address on imx8mm

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -44,7 +44,7 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         # This applies to imx8mm, imx8mq (EVK and MaaXBoard), imx8mp when in aarch32 configuration
         # It should be possible to use a uimage format but when tried nothing
         # runs after uboot.
-        set(IMAGE_START_ADDR 0x41000000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR 0x42000000 CACHE INTERNAL "" FORCE)
     endif()
     if(KernelPlatformHikey AND KernelSel4ArchAarch32)
         # This is preserving what the Hikey's bootloader requires.


### PR DESCRIPTION
The port of the hardware debug API to aarch64 has increased the size of some debug images to the point that the address range the image is loaded at overlaps with the address range the elf-loader relocates to and expects to run at. This was solved on aarch64 by shifting the uboot load address to 0x42000000. We do not differentiate between aarch32 and aarch64 images in uboot, and the aarch32 elfloader is not relocated, so the configuration in this commit must be changed to have the aarch32 elfloader expect to be executed from the new load address.