### PR TITLE
simulation: pass SMP number to QEMU

### DIFF
--- a/cmake-tool/helpers/simulation.cmake
+++ b/cmake-tool/helpers/simulation.cmake
@@ -166,6 +166,11 @@ function(GenerateSimulateScript)
     else()
         set(error "Unsupported platform or architecture for simulation")
     endif()
+
+    if(SMP)
+        string(APPEND qemu_sim_extra_args " -smp ${KernelMaxNumNodes}")
+    endif()
+
     set(sim_path "${CMAKE_BINARY_DIR}/simulate")
     set(gdb_path "${CMAKE_BINARY_DIR}/launch_gdb")
     if(NOT "${error}" STREQUAL "")


### PR DESCRIPTION

This passes `-smp N` argument to QEMU simulator for SMP build so that the simulate script launches with right number of SMP cores.
