### PR TITLE
cmake-tool: update GettingStarted link

### DIFF
--- a/cmake-tool/README.md
+++ b/cmake-tool/README.md
@@ -27,9 +27,9 @@ the actual build.
 It is assumed that
 
  * CMake of an appropriate version is installed
- * You are using the Ninja CMake generator 
+ * You are using the Ninja CMake generator
  * You understand how to checkout projects using the repo tool as described on the
-   [Getting started](https://docs.sel4.systems/GettingStarted) page
+   [seL4 docsite](https://docs.sel4.systems/Resources#running-sel4)
 
 #### Basic build initialisation
 


### PR DESCRIPTION
GettingStarted page was renamed and was not describing what this page claimed. Point to a sub-heading that at least sort-of does.