### PR TITLE
Support for Cheshire (CVA6)

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -12,7 +12,7 @@ include_guard(GLOBAL)
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     set(
         binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;tqma8xqp1gb;bcm2711;rocketchip;star64"
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;tqma8xqp1gb;bcm2711;rocketchip;star64;cheshire"
     )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "tx2;am335x")
@@ -65,6 +65,10 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     endif()
     if(KernelPlatformStar64)
         set(IMAGE_START_ADDR 0x60000000 CACHE INTERNAL "" FORCE)
+    endif()
+    if(KernelPlatformCheshire)
+        set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
+        set(IMAGE_START_ADDR 0x80200000 CACHE INTERNAL "" FORCE)
     endif()
 endfunction()
 


### PR DESCRIPTION
Prevents building OpenSBI automatically in Cmake builds.