### PR TITLE
elfloader: cast linker symbol to avoid warining

### DIFF
--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -114,7 +114,7 @@ void main(UNUSED void *arg)
     /* Print welcome message. */
     printf("\nELF-loader started on ");
     print_cpuid();
-    printf("  paddr=[%p..%p]\n", _text, _end - 1);
+    printf("  paddr=[%p..%p]\n", _text, (uintptr_t)_end - 1);
 
 #if defined(CONFIG_IMAGE_UIMAGE)
 


### PR DESCRIPTION
The _end symbol is declared as char[]. Newer compilers raise warnings about array out of bounds access here:
error: array subscript -1 is outside array bounds of ‘char[]’ [-Werror=array-bounds]