### PR TITLE
elfloader: Revert part of #93

### DIFF
--- a/elfloader-tool/src/arch-arm/sys_boot.c
+++ b/elfloader-tool/src/arch-arm/sys_boot.c
@@ -116,7 +116,7 @@ void main(UNUSED void *arg)
     print_cpuid();
     printf("  paddr=[%p..%p]\n", _text, (uintptr_t)_end - 1);
 
-#if defined(CONFIG_IMAGE_UIMAGE) || defined(CONFIG_IMAGE_BINARY)
+#if defined(CONFIG_IMAGE_UIMAGE)
 
     /* U-Boot passes a DTB. Ancient bootloaders may pass atags. When booting via
      * bootelf argc is NULL.


### PR DESCRIPTION
Part of #93 enabled checking arg0 for a dtb pointer when loading as a binary. However because several CONFIG_IMAGE_BINARY configurations don't sanitize arg0 before calling main it's not yet safe to dereference the variable as a valid pointer.