### PR TITLE
Bump CMake version

### DIFF
--- a/cmake-tool/README.md
+++ b/cmake-tool/README.md
@@ -304,7 +304,7 @@ and so is relative to that directory.
 The contents of `awesome_system/awesome/CMakeLists.txt` would be something like
 
 ```cmake
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 include(../buildsystem/cmake-tool/base.cmake)
 add_subdirectory(../seL4_libs seL4_libs)
 include(../buildsystem/cmake-tool/configuration.cmake)

--- a/cmake-tool/all.cmake
+++ b/cmake-tool/all.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 # import some debug functions
 include("${CMAKE_CURRENT_LIST_DIR}/helpers/debug.cmake")

--- a/cmake-tool/base.cmake
+++ b/cmake-tool/base.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 # Include our common helpers
 list(
     APPEND

--- a/cmake-tool/common.cmake
+++ b/cmake-tool/common.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 include("${CMAKE_CURRENT_LIST_DIR}/helpers/application_settings.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/helpers/cakeml.cmake")

--- a/cmake-tool/default-CMakeLists.txt
+++ b/cmake-tool/default-CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 project(sel4-application NONE)
 
 include(settings.cmake)

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)

--- a/cmake-tool/helpers/cakeml.cmake
+++ b/cmake-tool/helpers/cakeml.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 find_program(HOLMAKE_BIN NAMES "Holmake")

--- a/cmake-tool/helpers/configure_file.cmake
+++ b/cmake-tool/helpers/configure_file.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 if(NOT CONFIGURE_INPUT_FILE)
     message(FATAL_ERROR "CONFIGURE_INPUT_FILE not set.")

--- a/cmake-tool/helpers/cross_compiling.cmake
+++ b/cmake-tool/helpers/cross_compiling.cmake
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 # This path is guaranteed to exist

--- a/cmake-tool/helpers/dts.cmake
+++ b/cmake-tool/helpers/dts.cmake
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 # This path is guaranteed to exist

--- a/cmake-tool/helpers/environment_flags.cmake
+++ b/cmake-tool/helpers/environment_flags.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 macro(add_default_compilation_options)

--- a/cmake-tool/helpers/external-project-helpers.cmake
+++ b/cmake-tool/helpers/external-project-helpers.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 include_guard(GLOBAL)
 

--- a/cmake-tool/helpers/make.cmake
+++ b/cmake-tool/helpers/make.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 # This takes a camkes produced dependency file (this means we can assume one dependency

--- a/cmake-tool/helpers/nanopb.cmake
+++ b/cmake-tool/helpers/nanopb.cmake
@@ -40,6 +40,7 @@ target_link_libraries(nanopb muslc)
 # Copy the generator directory to the build directory before
 # compiling python and proto files.
 add_custom_command(
+    PRE_BUILD
     TARGET nanopb
     COMMAND
         ${CMAKE_COMMAND} -E copy_directory

--- a/cmake-tool/helpers/rust.cmake
+++ b/cmake-tool/helpers/rust.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 find_path(

--- a/cmake-tool/polly_toolchains/FindPolly.cmake
+++ b/cmake-tool/polly_toolchains/FindPolly.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 # Save path to checkout of https://github.com/ruslo/polly
 macro(FindPolly)

--- a/cmake-tool/projects.cmake
+++ b/cmake-tool/projects.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 file(GLOB result RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" projects/*/CMakeLists.txt)
 

--- a/elfloader-tool/CMakeLists.txt
+++ b/elfloader-tool/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(elfloader C ASM)
 

--- a/elfloader-tool/helpers.cmake
+++ b/elfloader-tool/helpers.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 # Hook for CAmkES build system. This allows CAmkES projects to
 # force a particular rootserver location.


### PR DESCRIPTION
Compatibility with versions <3.10 is going away.

As it happens, we're not using any CMake features that have changed between 3.7 and 3.16, so bump the lowest version to 3.16.