### PR TITLE
Bump required cmake version

### DIFF
--- a/misc/style-cmake.sh
+++ b/misc/style-cmake.sh
@@ -14,7 +14,6 @@ PROGNAME=${0##*/}
 # to provide definitions for custom function formatting.
 CMAKE_FMT="--line-width 100 \
            --tab-size 4 \
-           --max-subargs-per-line 3 \
            --separate-ctrl-name-with-space False \
            --separate-fn-name-with-space False \
            --dangle-parens True \
@@ -24,7 +23,7 @@ CMAKE_FMT="--line-width 100 \
 
 # cmake-format sends its version info to standard error.  :-/
 CF_VERSION=$(cmake-format --version 2>&1)
-DESIRED_VERSION=0.4.5
+DESIRED_VERSION=0.6.13
 
 case "$CF_VERSION" in
     ("")


### PR DESCRIPTION
As decided in the most recent TSC meeting, bump the required cmake version to the latest available at the moment. Update command line options accordingly (`--max-subargs-per-line` option no longer exists).

This will change/complain about the style in many of our existing `cmake` files, but at some point we do need to switch, because to keep the old version working, we'd need to pin too many other packages to old versions and thereby downgrade other tools.

See also https://github.com/seL4/seL4/pull/1479
