### PR TITLE
SBI fixes

### DIFF
--- a/elfloader-tool/include/arch-riscv/sbi.h
+++ b/elfloader-tool/include/arch-riscv/sbi.h
@@ -24,8 +24,8 @@
     register uintptr_t a2 asm ("a2") = (uintptr_t)(arg2);   \
     register uintptr_t a7 asm ("a7") = (uintptr_t)(which);  \
     asm volatile ("ecall"                   \
-              : "+r" (a0)               \
-              : "r" (a1), "r" (a2), "r" (a7)        \
+              : "+r" (a0), "+r" (a1)        \
+              : "r" (a2), "r" (a7)          \
               : "memory");              \
     a0;                         \
 })
@@ -40,8 +40,8 @@
     register uintptr_t a6 asm ("a6") = (uintptr_t)(which);  \
     register uintptr_t a7 asm ("a7") = (uintptr_t)(extension); \
     asm volatile ("ecall"                   \
-              : "+r" (a0)               \
-              : "r" (a1), "r" (a2), "r" (a6), "r" (a7)      \
+              : "+r" (a0), "+r" (a1)        \
+              : "r" (a2), "r" (a6), "r" (a7)\
               : "memory");              \
     a0;                         \
 })

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -152,7 +152,7 @@ static void set_and_wait_for_ready(int hart_id, int core_id)
 
     /* Wait untill all cores are go */
     for (int i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
-        while (__atomic_load_n(&core_ready[i], __ATOMIC_RELAXED) == 0) ;
+        while (__atomic_load_n(&core_ready[i], __ATOMIC_ACQUIRE) == 0) ;
     }
 }
 #endif

--- a/elfloader-tool/src/arch-riscv/boot.c
+++ b/elfloader-tool/src/arch-riscv/boot.c
@@ -212,12 +212,11 @@ static int run_elfloader(UNUSED int hart_id, void *bootloader_dtb)
     /* Unleash secondary cores */
     __atomic_store_n(&secondary_go, 1, __ATOMIC_RELEASE);
 
-    /* Start all cores */
-    int i = 0;
-    while (i < CONFIG_MAX_NUM_NODES && hsm_exists) {
-        i++;
-        if (i != hart_id) {
-            sbi_hart_start(i, secondary_harts, i);
+    /* Start all other cores */
+    for (int i = 0; i < CONFIG_MAX_NUM_NODES && hsm_exists; ++i) {
+        int h = i + CONFIG_FIRST_HART_ID;
+        if (h != hart_id) {
+            sbi_hart_start(h, secondary_harts, h);
         }
     }
 


### PR DESCRIPTION
With some luck it fixes the P550 boot problems at https://github.com/seL4/ci-actions/pull/420. I restrained myself to obvious improvements instead of any major changes.

The whole hard_id - logical core id stuff is extremely convoluted, both in the kernel as Elfloader, all to support a mapping that isn't 1:1. But the Elfloader code which calls `sbi_hart_start` assumes it is 1:1, so I'm not sure why we bother with all this. The only code needing FIRST_HART_ID is the (non-SMP?) plic code. Similarly, I don't understand why we go through all the complexity of switching harts if it isn't CONFIG_FIRST_HART, it doesn't matter which core does the shared init part. After synchronisation and jumping to the kernel it's all a big race anyway.