### PR TITLE
elfloader: limit retain to clang

### DIFF
--- a/elfloader-tool/include/drivers/common.h
+++ b/elfloader-tool/include/drivers/common.h
@@ -43,7 +43,7 @@ struct elfloader_driver {
 extern struct elfloader_driver *__start__driver_list[];
 extern struct elfloader_driver *__stop__driver_list[];
 
-#if defined(__has_attribute) && __has_attribute(retain)
+#if defined(__has_attribute) && __has_attribute(retain) && defined(__clang__)
 #define ELFLOADER_DRIVER(_name) \
     const struct elfloader_driver *_driver_list_##_name \
         __attribute__((unused,retain,section("_driver_list"))) = &_name;


### PR DESCRIPTION
Because of GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587 using has_attribute is not reliable and can give compile warnings that will be turned into errors because of -Werror.

The retain atribute was added to support linking with LLVM's linker in commit be8277a84c0c59b472909877540d55d53739001e.

Cross reference: https://github.com/seL4/seL4_libs/pull/103.