### PR TITLE
cmake-format: call on single files only

### DIFF
--- a/misc/style-cmake.sh
+++ b/misc/style-cmake.sh
@@ -40,4 +40,6 @@ case "$CF_VERSION" in
         ;;
 esac
 
-cmake-format -i $CMAKE_FMT "$@"
+for f in "$@"; do
+  cmake-format -i $CMAKE_FMT "$f"
+done


### PR DESCRIPTION
camke-format 0.6.13 forgets its command line options after the first file when called with multiple files.
