### PR TITLE
simulate.py: don't unconditionally reset terminal

### DIFF
--- a/cmake-tool/simulate_scripts/simulate.py
+++ b/cmake-tool/simulate_scripts/simulate.py
@@ -42,6 +42,8 @@ def parse_args():
     parser.add_argument('--extra-cpu-opts', dest='qemu_sim_extra_cpu_opts', type=str,
                         help="Additional cpu options to append onto the existing CPU options",
                         default="")
+    parser.add_argument("-r", "--reset-terminal", dest="reset_terminal", action="store_true",
+                        help="Reset the terminal after QEMU exists")
     args = parser.parse_args()
     return args
 
@@ -102,6 +104,7 @@ if __name__ == "__main__":
     else:
         delay = 2  # in seconds
 
-    time.sleep(delay)
+    if args.reset_terminal:
+        time.sleep(delay)
 
-    subprocess.call("tput reset", shell=True)
+        subprocess.call("tput reset", shell=True)


### PR DESCRIPTION
The commit by @kent-mcleod f63e3d5b783431bdbfa5861dec6bc34311357f20 which added this says that "Qemu leaves the terminal in an inconsistent state" but personally I've never seen this, and whenever I run tests in simulate w/QEMU I need to always remember to remove this option from the script. I've seen coworkers also have to do this. The issue is that "tput reset" also clears the screen which means you can't see the log outputs.

Instead I've turned this into an option for --reset-terminal in case anyway actually wants to use this.