### PR TITLE
elfloader: Use U-Boot uImages for Cheshire

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -12,10 +12,10 @@ include_guard(GLOBAL)
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     set(
         binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64;cheshire"
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64"
     )
     set(efi_list "tk1;rockpro64;quartz64")
-    set(uimage_list "hifive-p550;tx2;am335x")
+    set(uimage_list "hifive-p550;tx2;am335x;cheshire")
     if(
         ${kernel_platform} IN_LIST efi_list
         OR (${kernel_platform} STREQUAL "hikey" AND ${kernel_sel4_arch} STREQUAL "aarch64")
@@ -67,11 +67,7 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     if(KernelPlatformStar64)
         set(IMAGE_START_ADDR 0x60000000 CACHE INTERNAL "" FORCE)
     endif()
-    if(KernelPlatformCheshire)
-        set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
-        set(IMAGE_START_ADDR 0x80200000 CACHE INTERNAL "" FORCE)
-    endif()
-    if(KernelPlatformHifiveP550)
+    if(KernelPlatformHifiveP550 OR KernelPlatformCheshire)
         set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
     endif()
 endfunction()


### PR DESCRIPTION
This is not ready until I update the documentation for Cheshire; the good thing about these images is that you can still load them manually through GDB as long as you count for the header offset, but u-boot can also load them