### PR TITLE
elfloader: use ELFs on Cheshire; change start addr

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -12,7 +12,7 @@ include_guard(GLOBAL)
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     set(
         binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64;cheshire"
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64"
     )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "hifive-p550;tx2;am335x")
@@ -69,7 +69,7 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     endif()
     if(KernelPlatformCheshire)
         set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
-        set(IMAGE_START_ADDR 0x80200000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR 0x90000000 CACHE INTERNAL "" FORCE)
     endif()
     if(KernelPlatformHifiveP550)
         set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -10,83 +10,151 @@ cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
-    set(
-        binary_list
+    set(binary_list
         "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64"
     )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "hifive-p550;tx2;am335x")
-    if(
-        ${kernel_platform} IN_LIST efi_list
-        OR (${kernel_platform} STREQUAL "hikey" AND ${kernel_sel4_arch} STREQUAL "aarch64")
+    if(${kernel_platform} IN_LIST efi_list OR (${kernel_platform} STREQUAL "hikey"
+                                               AND ${kernel_sel4_arch} STREQUAL "aarch64")
     )
-        set(ElfloaderImage "efi" CACHE STRING "" FORCE)
+        set(ElfloaderImage
+            "efi"
+            CACHE STRING "" FORCE
+        )
     elseif(${kernel_platform} IN_LIST uimage_list)
-        set(ElfloaderImage "uimage" CACHE STRING "" FORCE)
+        set(ElfloaderImage
+            "uimage"
+            CACHE STRING "" FORCE
+        )
     elseif(${kernel_platform} IN_LIST binary_list)
-        set(ElfloaderImage "binary" CACHE STRING "" FORCE)
+        set(ElfloaderImage
+            "binary"
+            CACHE STRING "" FORCE
+        )
     else()
-        set(ElfloaderImage "elf" CACHE STRING "" FORCE)
+        set(ElfloaderImage
+            "elf"
+            CACHE STRING "" FORCE
+        )
     endif()
 
     if(${kernel_platform} STREQUAL "tk1" AND ${kernel_sel4_arch} STREQUAL "arm_hyp")
-        set(ElfloaderMode "hypervisor" CACHE STRING "" FORCE)
-        set(ElfloaderMonitorHook ON CACHE BOOL "" FORCE)
+        set(ElfloaderMode
+            "hypervisor"
+            CACHE STRING "" FORCE
+        )
+        set(ElfloaderMonitorHook
+            ON
+            CACHE BOOL "" FORCE
+        )
     endif()
-    if(
-        (KernelPlatformImx8mm-evk OR KernelPlatImx8mq OR KernelPlatformImx8mp-evk)
-        AND KernelSel4ArchAarch32
+    if((KernelPlatformImx8mm-evk
+        OR KernelPlatImx8mq
+        OR KernelPlatformImx8mp-evk)
+       AND KernelSel4ArchAarch32
     )
-        set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
+        set(ElfloaderArmV8LeaveAarch64
+            ON
+            CACHE BOOL "" FORCE
+        )
         # This applies to imx8mm, imx8mq (EVK and MaaXBoard), imx8mp when in aarch32 configuration
         # It should be possible to use a uimage format but when tried nothing
         # runs after uboot.
-        set(IMAGE_START_ADDR 0x42000000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR
+            0x42000000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformHikey AND KernelSel4ArchAarch32)
         # This is preserving what the Hikey's bootloader requires.
-        set(IMAGE_START_ADDR 0x1000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR
+            0x1000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformZynqmp AND KernelSel4ArchAarch32)
-        set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
-        set(IMAGE_START_ADDR 0x8000000 CACHE INTERNAL "" FORCE)
+        set(ElfloaderArmV8LeaveAarch64
+            ON
+            CACHE BOOL "" FORCE
+        )
+        set(IMAGE_START_ADDR
+            0x8000000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformRpi4)
         if(KernelSel4ArchAarch32)
-            set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
+            set(ElfloaderArmV8LeaveAarch64
+                ON
+                CACHE BOOL "" FORCE
+            )
         endif()
-        set(IMAGE_START_ADDR 0x10000000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR
+            0x10000000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformSpike OR KernelPlatformQEMURiscVVirt)
         # Spike/qemu loads elfloader to either 0x80200000 or 0x80400000
         # But the RISC-V kernel is currently loaded to a different
         # address than what's modelled by the shoehorn.py tool.
         # So force the start address to one that works.
-        set(IMAGE_START_ADDR 0x81000000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR
+            0x81000000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformStar64)
-        set(IMAGE_START_ADDR 0x60000000 CACHE INTERNAL "" FORCE)
+        set(IMAGE_START_ADDR
+            0x60000000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformCheshire)
-        set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
-        set(IMAGE_START_ADDR 0x90000000 CACHE INTERNAL "" FORCE)
+        set(UseRiscVOpenSBI
+            OFF
+            CACHE BOOL "" FORCE
+        )
+        set(IMAGE_START_ADDR
+            0x90000000
+            CACHE INTERNAL "" FORCE
+        )
     endif()
     if(KernelPlatformHifiveP550)
-        set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
+        set(UseRiscVOpenSBI
+            OFF
+            CACHE BOOL "" FORCE
+        )
     endif()
 endfunction()
 
 function(ApplyCommonSimulationSettings kernel_sel4_arch)
     if("${kernel_sel4_arch}" STREQUAL "x86_64" OR "${kernel_sel4_arch}" STREQUAL "ia32")
         # Generally we cannot simulate some more recent features
-        set(KernelSupportPCID OFF CACHE BOOL "" FORCE)
+        set(KernelSupportPCID
+            OFF
+            CACHE BOOL "" FORCE
+        )
         if("${kernel_sel4_arch}" STREQUAL "ia32")
-            set(KernelFSGSBase gdt CACHE STRING "" FORCE)
+            set(KernelFSGSBase
+                gdt
+                CACHE STRING "" FORCE
+            )
         else()
-            set(KernelFSGSBase msr CACHE STRING "" FORCE)
+            set(KernelFSGSBase
+                msr
+                CACHE STRING "" FORCE
+            )
         endif()
-        set(KernelIOMMU OFF CACHE BOOL "" FORCE)
-        set(KernelFPU FXSAVE CACHE STRING "" FORCE)
+        set(KernelIOMMU
+            OFF
+            CACHE BOOL "" FORCE
+        )
+        set(KernelFPU
+            FXSAVE
+            CACHE STRING "" FORCE
+        )
     endif()
 endfunction()
 
@@ -94,22 +162,46 @@ function(ApplyCommonReleaseVerificationSettings release verification)
     # Setup flags for different combinations of 'release' (performance optimized builds) and
     # 'verification' (verification friendly features) builds
     if(release)
-        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
-        set(KernelPrinting OFF CACHE BOOL "" FORCE)
+        set(CMAKE_BUILD_TYPE
+            "Release"
+            CACHE STRING "" FORCE
+        )
+        set(KernelPrinting
+            OFF
+            CACHE BOOL "" FORCE
+        )
     else()
-        set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+        set(CMAKE_BUILD_TYPE
+            "Debug"
+            CACHE STRING "" FORCE
+        )
     endif()
     if(verification)
-        set(KernelVerificationBuild ON CACHE BOOL "" FORCE)
+        set(KernelVerificationBuild
+            ON
+            CACHE BOOL "" FORCE
+        )
     else()
-        set(KernelVerificationBuild OFF CACHE BOOL "" FORCE)
+        set(KernelVerificationBuild
+            OFF
+            CACHE BOOL "" FORCE
+        )
     endif()
     # If neither release nor verification then enable debug facilities, otherwise turn them off
     if((NOT release) AND (NOT verification))
-        set(KernelDebugBuild ON CACHE BOOL "" FORCE)
-        set(KernelPrinting ON CACHE BOOL "" FORCE)
+        set(KernelDebugBuild
+            ON
+            CACHE BOOL "" FORCE
+        )
+        set(KernelPrinting
+            ON
+            CACHE BOOL "" FORCE
+        )
     else()
-        set(KernelDebugBuild OFF CACHE BOOL "" FORCE)
+        set(KernelDebugBuild
+            OFF
+            CACHE BOOL "" FORCE
+        )
     endif()
     mark_as_advanced(CMAKE_BUILD_TYPE)
 endfunction()
@@ -157,8 +249,7 @@ function(correct_platform_strings)
         message(FATAL_ERROR "KernelRiscVSel4Arch is no longer supported, use PLATFROM")
     endif()
 
-    set(
-        platform_aliases
+    set(platform_aliases
         # The elements of this list are:
         #      "-"+<name of architecture #1 specific platform variable>
         #      <chip family>:<board_1>,<board_2>...
@@ -214,18 +305,15 @@ function(correct_platform_strings)
 
         set(plat "${CMAKE_MATCH_1}")
 
-        string(
-            REPLACE
-                ","
-                ";"
-                item_board_list
-                "${CMAKE_MATCH_2}"
-        )
+        string(REPLACE "," ";" item_board_list "${CMAKE_MATCH_2}")
 
         # remember board alias names, we need to build a complete list
         list(APPEND all_boards "${item_board_list}")
 
-        if(kernel_var OR ("${PLATFORM}" STREQUAL "") OR (NOT "${PLATFORM}" IN_LIST item_board_list))
+        if(kernel_var
+           OR ("${PLATFORM}" STREQUAL "")
+           OR (NOT "${PLATFORM}" IN_LIST item_board_list)
+        )
             continue()
         endif()
 
@@ -235,7 +323,10 @@ function(correct_platform_strings)
                     "config mismatch, wont overwrite KernelPlatform=${KernelPlatform} with ${plat}"
             )
         endif()
-        set(KernelPlatform "${plat}" CACHE STRING "" FORCE)
+        set(KernelPlatform
+            "${plat}"
+            CACHE STRING "" FORCE
+        )
 
         if(${block_kernel_var} AND (NOT "${${block_kernel_var}}" STREQUAL "${PLATFORM}"))
             message(
@@ -244,17 +335,26 @@ function(correct_platform_strings)
             )
         endif()
         set(kernel_var "${block_kernel_var}")
-        set(${kernel_var} "${PLATFORM}" CACHE STRING "" FORCE)
+        set(${kernel_var}
+            "${PLATFORM}"
+            CACHE STRING "" FORCE
+        )
 
     endforeach()
 
     if(NOT kernel_var)
-        set(KernelPlatform "${PLATFORM}" CACHE STRING "" FORCE)
+        set(KernelPlatform
+            "${PLATFORM}"
+            CACHE STRING "" FORCE
+        )
     endif()
 
     # declare a special variable that some CMake files expect to hold a list of
     # all board alias names from the "database" above
-    set(correct_platform_strings_platform_aliases "${all_boards}" CACHE INTERNAL "")
+    set(correct_platform_strings_platform_aliases
+        "${all_boards}"
+        CACHE INTERNAL ""
+    )
 
     # printing a message about the adaption is optional. When CMake is
     # invoked multiple times to get a stable configuration, we print this
@@ -269,23 +369,41 @@ function(correct_platform_strings)
 
     set(_REWRITE ON)
 
-    if(ARM OR AARCH32 OR AARCH32HF)
+    if(ARM
+       OR AARCH32
+       OR AARCH32HF
+    )
         # "arm_hyp" was needed as a new kernel architecture long time ago when
         # the scripts that produced a kernel that was given to L4V could only
         # handle changing the kernel architecture. It was used to mean
         # "aarch32 + hyp extensions". Now it would be possible to completely
         # remove it and follow the same pattern as aarch64.
         if(ARM_HYP OR ("${KernelSel4Arch}" STREQUAL "arm_hyp"))
-            set(KernelSel4Arch "arm_hyp" CACHE STRING "" FORCE)
+            set(KernelSel4Arch
+                "arm_hyp"
+                CACHE STRING "" FORCE
+            )
         else()
-            set(KernelSel4Arch "aarch32" CACHE STRING "" FORCE)
+            set(KernelSel4Arch
+                "aarch32"
+                CACHE STRING "" FORCE
+            )
         endif()
     elseif(AARCH64)
-        set(KernelSel4Arch "aarch64" CACHE STRING "" FORCE)
+        set(KernelSel4Arch
+            "aarch64"
+            CACHE STRING "" FORCE
+        )
     elseif(RISCV64)
-        set(KernelSel4Arch "riscv64" CACHE STRING "" FORCE)
+        set(KernelSel4Arch
+            "riscv64"
+            CACHE STRING "" FORCE
+        )
     elseif(RISCV32)
-        set(KernelSel4Arch "riscv32" CACHE STRING "" FORCE)
+        set(KernelSel4Arch
+            "riscv32"
+            CACHE STRING "" FORCE
+        )
     else()
         set(_REWRITE OFF)
     endif()
@@ -297,6 +415,9 @@ function(correct_platform_strings)
     # otherwise the ccache gets interrupted with output everytime it is used.
     # The ccache also has a mechanism for showing what config options get
     # changed after a configuration anyway so the user will still be informed.
-    set(correct_platform_strings_no_print ON CACHE INTERNAL "")
+    set(correct_platform_strings_no_print
+        ON
+        CACHE INTERNAL ""
+    )
 
 endfunction()


### PR DESCRIPTION
Cheshire loads images over JTAG (OpenOCD + GDB) and so ELF files make it easier to just load seL4 and then go. Binary files *work* but need to be manually loaded at the correct address, so are more annoying to work with. In the case of U-Boot anyhow, we need to use uImage and it is (a) hard to load using GDB (need to offset 64 bytes for the header every time you load it), and b) can be generated by the `make-uimage` from seL4_tools easily (and this is what is done by our machine queue setup locally).

Also, the set address of 0x80200000 breaks the elfloader currently as the location of the embedded DTB overlaps the kernel load address and so the current binary images *cannot* be used to boot seL4.

With: https://github.com/seL4/docs/pull/297