### PR TITLE
Add support for stm32mp2 SoC family

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -11,7 +11,7 @@ include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     set(binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;rk3568"
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;star64;rk3568;stm32mp2"
     )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "hifive-p550;tx2;am335x;bananapi-f3;star64")
@@ -135,6 +135,12 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         set(UseRiscVOpenSBI
             OFF
             CACHE BOOL "" FORCE
+        )
+    endif()
+    if(KernelPlatformMP2)
+        set(IMAGE_START_ADDR
+            0x88000000
+            CACHE INTERNAL "" FORCE
         )
     endif()
     if(KernelPlatformBananapiF3)

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -11,7 +11,7 @@ include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
     set(binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;rk3568"
+        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;rk3568;stm32mp2"
     )
     set(efi_list "tk1;rockpro64;quartz64")
     set(uimage_list "hifive-p550;tx2;am335x;bananapi-f3;star64")
@@ -135,6 +135,12 @@ function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
         set(UseRiscVOpenSBI
             OFF
             CACHE BOOL "" FORCE
+        )
+    endif()
+    if(KernelPlatformMP2)
+        set(IMAGE_START_ADDR
+            0x88000000
+            CACHE INTERNAL "" FORCE
         )
     endif()
     if(KernelPlatformBananapiF3)

--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -10,222 +10,113 @@ cmake_minimum_required(VERSION 3.16.0)
 include_guard(GLOBAL)
 
 function(ApplyData61ElfLoaderSettings kernel_platform kernel_sel4_arch)
-    set(binary_list
-        "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;rk3568;stm32mp2"
-    )
-    set(efi_list "tk1;rockpro64;quartz64")
-    set(uimage_list "hifive-p550;tx2;am335x;bananapi-f3;star64")
-    if(${kernel_platform} IN_LIST efi_list OR (${kernel_platform} STREQUAL "hikey"
-                                               AND ${kernel_sel4_arch} STREQUAL "aarch64")
-    )
-        set(ElfloaderImage
-            "efi"
-            CACHE STRING "" FORCE
-        )
-    elseif(${kernel_platform} IN_LIST uimage_list)
-        set(ElfloaderImage
-            "uimage"
-            CACHE STRING "" FORCE
-        )
-    elseif(${kernel_platform} IN_LIST binary_list)
-        set(ElfloaderImage
-            "binary"
-            CACHE STRING "" FORCE
-        )
-    else()
-        set(ElfloaderImage
-            "elf"
-            CACHE STRING "" FORCE
-        )
-    endif()
+  set(binary_list
+      "tx1;hikey;odroidc2;odroidc4;imx8mq-evk;imx8mm-evk;imx8mp-evk;hifive;bcm2837;tqma8xqp1gb;imx93;bcm2711;rocketchip;rk3568;stm32mp2"
+  )
+  set(efi_list "tk1;rockpro64;quartz64")
+  set(uimage_list "hifive-p550;tx2;am335x;bananapi-f3;star64")
+  if(${kernel_platform} IN_LIST efi_list OR (${kernel_platform} STREQUAL "hikey"
+                                             AND ${kernel_sel4_arch} STREQUAL "aarch64"))
+    set(ElfloaderImage "efi" CACHE STRING "" FORCE)
+  elseif(${kernel_platform} IN_LIST uimage_list)
+    set(ElfloaderImage "uimage" CACHE STRING "" FORCE)
+  elseif(${kernel_platform} IN_LIST binary_list)
+    set(ElfloaderImage "binary" CACHE STRING "" FORCE)
+  else()
+    set(ElfloaderImage "elf" CACHE STRING "" FORCE)
+  endif()
 
-    if(${kernel_platform} STREQUAL "tk1" AND ${kernel_sel4_arch} STREQUAL "arm_hyp")
-        set(ElfloaderMode
-            "hypervisor"
-            CACHE STRING "" FORCE
-        )
-        set(ElfloaderMonitorHook
-            ON
-            CACHE BOOL "" FORCE
-        )
+  if(${kernel_platform} STREQUAL "tk1" AND ${kernel_sel4_arch} STREQUAL "arm_hyp")
+    set(ElfloaderMode "hypervisor" CACHE STRING "" FORCE)
+    set(ElfloaderMonitorHook ON CACHE BOOL "" FORCE)
+  endif()
+  if((KernelPlatformImx8mm-evk OR KernelPlatImx8mq OR KernelPlatformImx8mp-evk)
+     AND KernelSel4ArchAarch32)
+    set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
+    # This applies to imx8mm, imx8mq (EVK and MaaXBoard), imx8mp when in aarch32 configuration
+    # It should be possible to use a uimage format but when tried nothing
+    # runs after uboot.
+    set(IMAGE_START_ADDR 0x42000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformHikey AND KernelSel4ArchAarch32)
+    # This is preserving what the Hikey's bootloader requires.
+    set(IMAGE_START_ADDR 0x1000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformRock3b)
+    set(IMAGE_START_ADDR 0x10000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformZynqmp AND KernelSel4ArchAarch32)
+    set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
+    set(IMAGE_START_ADDR 0x8000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformRpi4)
+    if(KernelSel4ArchAarch32)
+      set(ElfloaderArmV8LeaveAarch64 ON CACHE BOOL "" FORCE)
     endif()
-    if((KernelPlatformImx8mm-evk
-        OR KernelPlatImx8mq
-        OR KernelPlatformImx8mp-evk)
-       AND KernelSel4ArchAarch32
-    )
-        set(ElfloaderArmV8LeaveAarch64
-            ON
-            CACHE BOOL "" FORCE
-        )
-        # This applies to imx8mm, imx8mq (EVK and MaaXBoard), imx8mp when in aarch32 configuration
-        # It should be possible to use a uimage format but when tried nothing
-        # runs after uboot.
-        set(IMAGE_START_ADDR
-            0x42000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformHikey AND KernelSel4ArchAarch32)
-        # This is preserving what the Hikey's bootloader requires.
-        set(IMAGE_START_ADDR
-            0x1000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformRock3b)
-        set(IMAGE_START_ADDR
-            0x10000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformZynqmp AND KernelSel4ArchAarch32)
-        set(ElfloaderArmV8LeaveAarch64
-            ON
-            CACHE BOOL "" FORCE
-        )
-        set(IMAGE_START_ADDR
-            0x8000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformRpi4)
-        if(KernelSel4ArchAarch32)
-            set(ElfloaderArmV8LeaveAarch64
-                ON
-                CACHE BOOL "" FORCE
-            )
-        endif()
-        set(IMAGE_START_ADDR
-            0x10000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformSpike OR KernelPlatformQEMURiscVVirt)
-        # Spike/qemu loads elfloader to either 0x80200000 or 0x80400000
-        # But the RISC-V kernel is currently loaded to a different
-        # address than what's modelled by the shoehorn.py tool.
-        # So force the start address to one that works.
-        set(IMAGE_START_ADDR
-            0x81000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformStar64)
-        set(UseRiscVOpenSBI
-            OFF
-            CACHE BOOL "" FORCE
-        )
-        set(IMAGE_START_ADDR
-            0x60000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformCheshire)
-        set(UseRiscVOpenSBI
-            OFF
-            CACHE BOOL "" FORCE
-        )
-        set(IMAGE_START_ADDR
-            0x90000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformHifiveP550)
-        set(UseRiscVOpenSBI
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
-    if(KernelPlatformMP2)
-        set(IMAGE_START_ADDR
-            0x88000000
-            CACHE INTERNAL "" FORCE
-        )
-    endif()
-    if(KernelPlatformBananapiF3)
-        set(UseRiscVOpenSBI
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+    set(IMAGE_START_ADDR 0x10000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformSpike OR KernelPlatformQEMURiscVVirt)
+    # Spike/qemu loads elfloader to either 0x80200000 or 0x80400000
+    # But the RISC-V kernel is currently loaded to a different
+    # address than what's modelled by the shoehorn.py tool.
+    # So force the start address to one that works.
+    set(IMAGE_START_ADDR 0x81000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformStar64)
+    set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
+    set(IMAGE_START_ADDR 0x60000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformCheshire)
+    set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
+    set(IMAGE_START_ADDR 0x90000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformHifiveP550)
+    set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
+  endif()
+  if(KernelPlatformMP2)
+    set(IMAGE_START_ADDR 0x88000000 CACHE INTERNAL "" FORCE)
+  endif()
+  if(KernelPlatformBananapiF3)
+    set(UseRiscVOpenSBI OFF CACHE BOOL "" FORCE)
+  endif()
 endfunction()
 
 function(ApplyCommonSimulationSettings kernel_sel4_arch)
-    if("${kernel_sel4_arch}" STREQUAL "x86_64" OR "${kernel_sel4_arch}" STREQUAL "ia32")
-        # Generally we cannot simulate some more recent features
-        set(KernelSupportPCID
-            OFF
-            CACHE BOOL "" FORCE
-        )
-        if("${kernel_sel4_arch}" STREQUAL "ia32")
-            set(KernelFSGSBase
-                gdt
-                CACHE STRING "" FORCE
-            )
-        else()
-            set(KernelFSGSBase
-                msr
-                CACHE STRING "" FORCE
-            )
-        endif()
-        set(KernelIOMMU
-            OFF
-            CACHE BOOL "" FORCE
-        )
-        set(KernelFPU
-            FXSAVE
-            CACHE STRING "" FORCE
-        )
+  if("${kernel_sel4_arch}" STREQUAL "x86_64" OR "${kernel_sel4_arch}" STREQUAL "ia32")
+    # Generally we cannot simulate some more recent features
+    set(KernelSupportPCID OFF CACHE BOOL "" FORCE)
+    if("${kernel_sel4_arch}" STREQUAL "ia32")
+      set(KernelFSGSBase gdt CACHE STRING "" FORCE)
+    else()
+      set(KernelFSGSBase msr CACHE STRING "" FORCE)
     endif()
+    set(KernelIOMMU OFF CACHE BOOL "" FORCE)
+    set(KernelFPU FXSAVE CACHE STRING "" FORCE)
+  endif()
 endfunction()
 
 function(ApplyCommonReleaseVerificationSettings release verification)
-    # Setup flags for different combinations of 'release' (performance optimized builds) and
-    # 'verification' (verification friendly features) builds
-    if(release)
-        set(CMAKE_BUILD_TYPE
-            "Release"
-            CACHE STRING "" FORCE
-        )
-        set(KernelPrinting
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(CMAKE_BUILD_TYPE
-            "Debug"
-            CACHE STRING "" FORCE
-        )
-    endif()
-    if(verification)
-        set(KernelVerificationBuild
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(KernelVerificationBuild
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
-    # If neither release nor verification then enable debug facilities, otherwise turn them off
-    if((NOT release) AND (NOT verification))
-        set(KernelDebugBuild
-            ON
-            CACHE BOOL "" FORCE
-        )
-        set(KernelPrinting
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(KernelDebugBuild
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
-    mark_as_advanced(CMAKE_BUILD_TYPE)
+  # Setup flags for different combinations of 'release' (performance optimized builds) and
+  # 'verification' (verification friendly features) builds
+  if(release)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+    set(KernelPrinting OFF CACHE BOOL "" FORCE)
+  else()
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+  endif()
+  if(verification)
+    set(KernelVerificationBuild ON CACHE BOOL "" FORCE)
+  else()
+    set(KernelVerificationBuild OFF CACHE BOOL "" FORCE)
+  endif()
+  # If neither release nor verification then enable debug facilities, otherwise turn them off
+  if((NOT release) AND (NOT verification))
+    set(KernelDebugBuild ON CACHE BOOL "" FORCE)
+    set(KernelPrinting ON CACHE BOOL "" FORCE)
+  else()
+    set(KernelDebugBuild OFF CACHE BOOL "" FORCE)
+  endif()
+  mark_as_advanced(CMAKE_BUILD_TYPE)
 endfunction()
 
 # Try and map a PLATFORM value to a valid kernel platform and architecture
@@ -240,206 +131,162 @@ endfunction()
 # Calling this function will result in forced updates to the cache.
 function(correct_platform_strings)
 
-    if(KernelX86Sel4Arch)
-        # this used to be a common mechanism how x86 architectures were
-        # selected. It's deprecated now and PLATFORM should be used instead. As
-        # of Nov/2020, we don't make this an error to give everybody a chance
-        # to update their scripts.
-        if("${PLATFORM}" STREQUAL "")
-            if(NOT correct_platform_strings_no_print)
-                message(
-                    DEPRECATION
-                        "setting PLATFORM from deprecated KernelX86Sel4Arch: ${KernelX86Sel4Arch}"
-                )
-            endif()
-            set(PLATFORM "${KernelX86Sel4Arch}")
-        elseif("${PLATFORM}" STREQUAL "${KernelX86Sel4Arch}")
-            if(NOT correct_platform_strings_no_print)
-                message(DEPRECATION "KernelX86Sel4Arch is deprecated, use PLATFORM only")
-            endif()
-        else()
-            message(
-                FATAL_ERROR
-                    "PLATFORM=${PLATFORM} does not match KernelX86Sel4Arch=${KernelX86Sel4Arch}"
-            )
-        endif()
-    elseif(KernelArmSel4Arch)
-        # this has never been widely in use, so we stop supporting it
-        message(FATAL_ERROR "KernelArmSel4Arch is no longer supported, use PLATFROM")
-    elseif(KernelRiscVSel4Arch)
-        # this should not have been in use at all
-        message(FATAL_ERROR "KernelRiscVSel4Arch is no longer supported, use PLATFROM")
-    endif()
-
-    set(platform_aliases
-        # The elements of this list are:
-        #      "-"+<name of architecture #1 specific platform variable>
-        #      <chip family>:<board_1>,<board_2>...
-        #      <chip family>:<board_1>,<board_2>...
-        #      ...
-        #      "-"+<name of architecture #2 specific platform variable>
-        #      <chip family>:<board_1>,<board_2>...
-        #      ...
-        #  where this function will try to match PLATFORM against <board_n> and
-        #  then set:
-        #      KernelPlatform=<chip family>
-        #      <platform variable>=<board_n>
-        # Note that <board_n> must be a unique name, as the first match will be
-        # used. If there was no match for any board the function will set:
-        #     KernelPlatform=${PLATFORM}
-        # and leave all further setup to the architecture/platform specific
-        # configuration to <sel4 kernel>/src/plat/*/config.cmake
-        #
-        "-KernelRiscVPlatform"
-        "rocketchip:rocketchip-base,rocketchip-zcu102"
-        "-KernelARMPlatform"
-        "imx6:sabre,wandq,nitrogen6sx"
-        "bcm2837:rpi3"
-        "bcm2711:rpi4"
-        "exynos5:exynos5250,exynos5410,exynos5422"
-        "am335x:am335x-boneblack,am335x-boneblue,am335x-bone"
-        "zynqmp:zcu102,ultra96,ultra96v2"
-        "-KernelSel4Arch"
-        "pc99:x86_64,ia32"
-    )
-
-    set(all_boards "")
-    set(block_kernel_var "")
-    set(kernel_var "")
-
-    foreach(item IN LISTS platform_aliases)
-
-        if(item MATCHES "^-(.*)$")
-            set(block_kernel_var "${CMAKE_MATCH_1}")
-            continue()
-        endif()
-
-        if(NOT block_kernel_var)
-            message(
-                FATAL_ERROR
-                    "platform_aliases must set architecture specific kernel platform variable first"
-            )
-        endif()
-
-        if(NOT item MATCHES "^(.*):(.*)$")
-            message(FATAL_ERROR "invalid line in platform_aliases: ${item}")
-        endif()
-
-        set(plat "${CMAKE_MATCH_1}")
-
-        string(REPLACE "," ";" item_board_list "${CMAKE_MATCH_2}")
-
-        # remember board alias names, we need to build a complete list
-        list(APPEND all_boards "${item_board_list}")
-
-        if(kernel_var
-           OR ("${PLATFORM}" STREQUAL "")
-           OR (NOT "${PLATFORM}" IN_LIST item_board_list)
-        )
-            continue()
-        endif()
-
-        if(KernelPlatform AND (NOT "${KernelPlatform}" STREQUAL "${plat}"))
-            message(
-                FATAL_ERROR
-                    "config mismatch, wont overwrite KernelPlatform=${KernelPlatform} with ${plat}"
-            )
-        endif()
-        set(KernelPlatform
-            "${plat}"
-            CACHE STRING "" FORCE
-        )
-
-        if(${block_kernel_var} AND (NOT "${${block_kernel_var}}" STREQUAL "${PLATFORM}"))
-            message(
-                FATAL_ERROR
-                    "config mismatch, wont overwrite ${block_kernel_var}=${${block_kernel_var}} with ${PLATFORM}"
-            )
-        endif()
-        set(kernel_var "${block_kernel_var}")
-        set(${kernel_var}
-            "${PLATFORM}"
-            CACHE STRING "" FORCE
-        )
-
-    endforeach()
-
-    if(NOT kernel_var)
-        set(KernelPlatform
-            "${PLATFORM}"
-            CACHE STRING "" FORCE
-        )
-    endif()
-
-    # declare a special variable that some CMake files expect to hold a list of
-    # all board alias names from the "database" above
-    set(correct_platform_strings_platform_aliases
-        "${all_boards}"
-        CACHE INTERNAL ""
-    )
-
-    # printing a message about the adaption is optional. When CMake is
-    # invoked multiple times to get a stable configuration, we print this
-    # for the first run only.
-    if(NOT correct_platform_strings_no_print)
-        message(STATUS "Set platform details from PLATFORM=${PLATFORM}")
-        message(STATUS "  KernelPlatform: ${KernelPlatform}")
-        if(kernel_var)
-            message(STATUS "  ${kernel_var}: ${${kernel_var}}")
-        endif()
-    endif()
-
-    set(_REWRITE ON)
-
-    if(ARM
-       OR AARCH32
-       OR AARCH32HF
-    )
-        # "arm_hyp" was needed as a new kernel architecture long time ago when
-        # the scripts that produced a kernel that was given to L4V could only
-        # handle changing the kernel architecture. It was used to mean
-        # "aarch32 + hyp extensions". Now it would be possible to completely
-        # remove it and follow the same pattern as aarch64.
-        if(ARM_HYP OR ("${KernelSel4Arch}" STREQUAL "arm_hyp"))
-            set(KernelSel4Arch
-                "arm_hyp"
-                CACHE STRING "" FORCE
-            )
-        else()
-            set(KernelSel4Arch
-                "aarch32"
-                CACHE STRING "" FORCE
-            )
-        endif()
-    elseif(AARCH64)
-        set(KernelSel4Arch
-            "aarch64"
-            CACHE STRING "" FORCE
-        )
-    elseif(RISCV64)
-        set(KernelSel4Arch
-            "riscv64"
-            CACHE STRING "" FORCE
-        )
-    elseif(RISCV32)
-        set(KernelSel4Arch
-            "riscv32"
-            CACHE STRING "" FORCE
-        )
+  if(KernelX86Sel4Arch)
+    # this used to be a common mechanism how x86 architectures were
+    # selected. It's deprecated now and PLATFORM should be used instead. As
+    # of Nov/2020, we don't make this an error to give everybody a chance
+    # to update their scripts.
+    if("${PLATFORM}" STREQUAL "")
+      if(NOT correct_platform_strings_no_print)
+        message(
+          DEPRECATION "setting PLATFORM from deprecated KernelX86Sel4Arch: ${KernelX86Sel4Arch}")
+      endif()
+      set(PLATFORM "${KernelX86Sel4Arch}")
+    elseif("${PLATFORM}" STREQUAL "${KernelX86Sel4Arch}")
+      if(NOT correct_platform_strings_no_print)
+        message(DEPRECATION "KernelX86Sel4Arch is deprecated, use PLATFORM only")
+      endif()
     else()
-        set(_REWRITE OFF)
+      message(
+        FATAL_ERROR "PLATFORM=${PLATFORM} does not match KernelX86Sel4Arch=${KernelX86Sel4Arch}")
     endif()
-    if(_REWRITE AND (NOT correct_platform_strings_no_print))
-        message(STATUS "Setting from flags KernelSel4Arch: ${KernelSel4Arch}")
+  elseif(KernelArmSel4Arch)
+    # this has never been widely in use, so we stop supporting it
+    message(FATAL_ERROR "KernelArmSel4Arch is no longer supported, use PLATFROM")
+  elseif(KernelRiscVSel4Arch)
+    # this should not have been in use at all
+    message(FATAL_ERROR "KernelRiscVSel4Arch is no longer supported, use PLATFROM")
+  endif()
+
+  set(platform_aliases
+      # The elements of this list are:
+      #      "-"+<name of architecture #1 specific platform variable>
+      #      <chip family>:<board_1>,<board_2>...
+      #      <chip family>:<board_1>,<board_2>...
+      #      ...
+      #      "-"+<name of architecture #2 specific platform variable>
+      #      <chip family>:<board_1>,<board_2>...
+      #      ...
+      #  where this function will try to match PLATFORM against <board_n> and
+      #  then set:
+      #      KernelPlatform=<chip family>
+      #      <platform variable>=<board_n>
+      # Note that <board_n> must be a unique name, as the first match will be
+      # used. If there was no match for any board the function will set:
+      #     KernelPlatform=${PLATFORM}
+      # and leave all further setup to the architecture/platform specific
+      # configuration to <sel4 kernel>/src/plat/*/config.cmake
+      #
+      "-KernelRiscVPlatform"
+      "rocketchip:rocketchip-base,rocketchip-zcu102"
+      "-KernelARMPlatform"
+      "imx6:sabre,wandq,nitrogen6sx"
+      "bcm2837:rpi3"
+      "bcm2711:rpi4"
+      "exynos5:exynos5250,exynos5410,exynos5422"
+      "am335x:am335x-boneblack,am335x-boneblue,am335x-bone"
+      "zynqmp:zcu102,ultra96,ultra96v2"
+      "-KernelSel4Arch"
+      "pc99:x86_64,ia32")
+
+  set(all_boards "")
+  set(block_kernel_var "")
+  set(kernel_var "")
+
+  foreach(item IN LISTS platform_aliases)
+
+    if(item MATCHES "^-(.*)$")
+      set(block_kernel_var "${CMAKE_MATCH_1}")
+      continue()
     endif()
 
-    # Only print out these info messages on first initialisation
-    # otherwise the ccache gets interrupted with output everytime it is used.
-    # The ccache also has a mechanism for showing what config options get
-    # changed after a configuration anyway so the user will still be informed.
-    set(correct_platform_strings_no_print
-        ON
-        CACHE INTERNAL ""
-    )
+    if(NOT block_kernel_var)
+      message(
+        FATAL_ERROR "platform_aliases must set architecture specific kernel platform variable first"
+      )
+    endif()
+
+    if(NOT item MATCHES "^(.*):(.*)$")
+      message(FATAL_ERROR "invalid line in platform_aliases: ${item}")
+    endif()
+
+    set(plat "${CMAKE_MATCH_1}")
+
+    string(REPLACE "," ";" item_board_list "${CMAKE_MATCH_2}")
+
+    # remember board alias names, we need to build a complete list
+    list(APPEND all_boards "${item_board_list}")
+
+    if(kernel_var OR ("${PLATFORM}" STREQUAL "") OR (NOT "${PLATFORM}" IN_LIST item_board_list))
+      continue()
+    endif()
+
+    if(KernelPlatform AND (NOT "${KernelPlatform}" STREQUAL "${plat}"))
+      message(
+        FATAL_ERROR "config mismatch, wont overwrite KernelPlatform=${KernelPlatform} with ${plat}")
+    endif()
+    set(KernelPlatform "${plat}" CACHE STRING "" FORCE)
+
+    if(${block_kernel_var} AND (NOT "${${block_kernel_var}}" STREQUAL "${PLATFORM}"))
+      message(
+        FATAL_ERROR
+          "config mismatch, wont overwrite ${block_kernel_var}=${${block_kernel_var}} with ${PLATFORM}"
+      )
+    endif()
+    set(kernel_var "${block_kernel_var}")
+    set(${kernel_var} "${PLATFORM}" CACHE STRING "" FORCE)
+
+  endforeach()
+
+  if(NOT kernel_var)
+    set(KernelPlatform "${PLATFORM}" CACHE STRING "" FORCE)
+  endif()
+
+  # declare a special variable that some CMake files expect to hold a list of
+  # all board alias names from the "database" above
+  set(correct_platform_strings_platform_aliases "${all_boards}" CACHE INTERNAL "")
+
+  # printing a message about the adaption is optional. When CMake is
+  # invoked multiple times to get a stable configuration, we print this
+  # for the first run only.
+  if(NOT correct_platform_strings_no_print)
+    message(STATUS "Set platform details from PLATFORM=${PLATFORM}")
+    message(STATUS "  KernelPlatform: ${KernelPlatform}")
+    if(kernel_var)
+      message(STATUS "  ${kernel_var}: ${${kernel_var}}")
+    endif()
+  endif()
+
+  set(_REWRITE ON)
+
+  if(ARM OR AARCH32 OR AARCH32HF)
+    # "arm_hyp" was needed as a new kernel architecture long time ago when
+    # the scripts that produced a kernel that was given to L4V could only
+    # handle changing the kernel architecture. It was used to mean
+    # "aarch32 + hyp extensions". Now it would be possible to completely
+    # remove it and follow the same pattern as aarch64.
+    if(ARM_HYP OR ("${KernelSel4Arch}" STREQUAL "arm_hyp"))
+      set(KernelSel4Arch "arm_hyp" CACHE STRING "" FORCE)
+    else()
+      set(KernelSel4Arch "aarch32" CACHE STRING "" FORCE)
+    endif()
+  elseif(AARCH64)
+    set(KernelSel4Arch "aarch64" CACHE STRING "" FORCE)
+  elseif(RISCV64)
+    set(KernelSel4Arch "riscv64" CACHE STRING "" FORCE)
+  elseif(RISCV32)
+    set(KernelSel4Arch "riscv32" CACHE STRING "" FORCE)
+  else()
+    set(_REWRITE OFF)
+  endif()
+  if(_REWRITE AND (NOT correct_platform_strings_no_print))
+    message(STATUS "Setting from flags KernelSel4Arch: ${KernelSel4Arch}")
+  endif()
+
+  # Only print out these info messages on first initialisation
+  # otherwise the ccache gets interrupted with output everytime it is used.
+  # The ccache also has a mechanism for showing what config options get
+  # changed after a configuration anyway so the user will still be informed.
+  set(correct_platform_strings_no_print ON CACHE INTERNAL "")
 
 endfunction()

--- a/elfloader-tool/src/drivers/uart/stm32mp2-uart.c
+++ b/elfloader-tool/src/drivers/uart/stm32mp2-uart.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026, STMicroelectronics
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <devices_gen.h>
+#include <drivers/common.h>
+#include <drivers/uart.h>
+
+#include <elfloader_common.h>
+
+#define UART_REG(mmio, x) ((volatile uint32_t *)(mmio + (x)))
+
+#define USART_CR1               0x00
+#define USART_CR2               0x04
+#define USART_ISR               0x1C
+#define USART_TDR               0x28
+
+/* USART_CR1 register fields */
+#define USART_CR1_UE            1
+#define USART_CR1_TE            8
+#define USART_CR1_FIFOEN        0x20000000U
+
+/* USART_CR2 register fields */
+#define USART_CR2_STOP          0x3000U
+
+/* USART_ISR register fields */
+#define USART_ISR_TXE           0x80U
+
+static int stm32mp2_uart_putchar(struct elfloader_device *dev, unsigned int c)
+{
+    volatile void *mmio = dev->region_bases[0];
+
+    /* Wait to be able to transmit. */
+    while (!(*UART_REG(mmio, USART_ISR) & USART_ISR_TXE));
+
+    /* Transmit. */
+    *UART_REG(mmio, USART_TDR) = c;
+
+    return 0;
+}
+
+static int stm32mp2_uart_init(struct elfloader_device *dev, UNUSED void *match_data)
+{
+    volatile void *mmio = dev->region_bases[0];
+    uint32_t v;
+
+    /* Disable UART */
+    v = *UART_REG(mmio, USART_CR1);
+    v &= ~USART_CR1_UE;
+    *UART_REG(mmio, USART_CR1) = v;
+
+    /* Configure UART */
+    v |= (USART_CR1_TE | USART_CR1_FIFOEN);
+    *UART_REG(mmio, USART_CR1) = v;
+
+    v = *UART_REG(mmio, USART_CR2);
+    v &= ~USART_CR2_STOP;
+    *UART_REG(mmio, USART_CR2) = v;
+
+    /* Enable UART */
+    v = *UART_REG(mmio, USART_CR1);
+    v |= USART_CR1_UE;
+    *UART_REG(mmio, USART_CR1) = v;
+
+    uart_set_out(dev);
+
+    return 0;
+}
+
+static const struct dtb_match_table stm32mp2_uart_matches[] = {
+    { .compatible = "st,stm32h7-uart" },
+    { .compatible = NULL /* sentinel */ },
+};
+
+static const struct elfloader_uart_ops stm32mp2_uart_ops = {
+    .putc = &stm32mp2_uart_putchar,
+};
+
+static const struct elfloader_driver stm32mp2_uart = {
+    .match_table = stm32mp2_uart_matches,
+    .type = DRIVER_UART,
+    .init = &stm32mp2_uart_init,
+    .ops = &stm32mp2_uart_ops,
+};
+
+ELFLOADER_DRIVER(stm32mp2_uart);


### PR DESCRIPTION
## Description

Add support to load the stm32mp2 kernel at address 0x84000000

The load base physical address for the loader is defined at 0x88000000

Link to kernel PR [seL4](https://github.com/seL4/seL4/pull/1592)
Depends on PR [RFC](https://github.com/seL4/seL4_tools/pull/244)