### PR TITLE
cmake style update

### DIFF
--- a/misc/style-cmake.sh
+++ b/misc/style-cmake.sh
@@ -13,12 +13,13 @@ PROGNAME=${0##*/}
 # Pass the cmake format as args such that cmake-format.py can be used
 # to provide definitions for custom function formatting.
 CMAKE_FMT="--line-width 100 \
-           --tab-size 4 \
+           --tab-size 2 \
            --separate-ctrl-name-with-space False \
            --separate-fn-name-with-space False \
-           --dangle-parens True \
+           --dangle-parens False \
            --command-case unchanged \
            --keyword-case unchanged \
+           --max-subgroups-hwrap 10 \
            --enable-markup False"
 
 # cmake-format sends its version info to standard error.  :-/


### PR DESCRIPTION
- Don't dangle closing params onto new line
- 2 char indent instead of 4
- Drastically increase the number of elements that can be in an arg group before switching to vertical mode