### PR TITLE
Workaround for what is likely a TX2 firmware bug

### DIFF
--- a/elfloader-tool/src/linker.lds
+++ b/elfloader-tool/src/linker.lds
@@ -48,15 +48,17 @@ SECTIONS
     . = ALIGN(16);
     .bss (NOLOAD) :
     {
-        . = ALIGN(0x1000);
-        core_stack_alloc = .;
-        . = . + CONFIG_MAX_NUM_NODES * 1 << 12;
-        core_stack_alloc_end = .;
         _bss = .;
         *(.sbss*)
         *(.bss)
         *(.bss.*)
         _bss_end = .;
+    }
+    .stack (NOLOAD) : ALIGN(0x1000)
+    {
+        core_stack_alloc = .;
+        . = . + CONFIG_MAX_NUM_NODES * 1 << 12;
+        core_stack_alloc_end = .;
     }
      _end = .;
 }


### PR DESCRIPTION
Depending on the size of the kernel, Elfloader causes SError traps. After a lot of testing and trying things out, it appears this is caused by speculative CPU memory accesses to device memory or something like that.

As this happens before Elfloader enables the MMU, this time it is not our mistake, but most likely a bug in the TX2 firmware or earlier bootloaders settings things up wrong.

The below change in no way fixes the underlaying bug or problem, but it does avoid triggering the fault.