### PR TITLE
fix elfloader: add UART MMIO mapping for debug output on AArch64 after MMU enable.

### DIFF
--- a/elfloader-tool/src/arch-arm/64/mmu.c
+++ b/elfloader-tool/src/arch-arm/64/mmu.c
@@ -11,6 +11,45 @@
 #include <mode/structures.h>
 #include <printf.h>
 #include <abort.h>
+#include <drivers/uart.h>
+
+/*
+* Create the 1:1 uart mapping so that the UART can be accessed after MMU enable.
+
+* For now we assume the uart memory ranges take no more than 2 MiB. We map the 2MiB block containing uart base together with a following block to avoid alignment issues.
+*/
+static inline void init_uart_downpages(vaddr_t elfloader_pud, volatile void *uart_base)
+{
+    vaddr_t uart_gb = (vaddr_t)uart_base & ~MASK(ARM_1GB_BLOCK_BITS);
+    vaddr_t uart_block;
+
+
+    if (GET_PUD_INDEX(uart_gb) != elfloader_pud) {
+        /* The UART is in a different 1 GiB block than the elfloader.
+            * We have no dedicated PMD table for that PUD entry, so use a
+            * 1 GiB block descriptor directly in the PUD.
+            */
+        _boot_pud_down[GET_PUD_INDEX(uart_gb)] = (uintptr_t)uart_gb
+                                                    | BIT(10)  /* access flag */
+                                                    | (0 << 2) /* MT_DEVICE_nGnRnE */
+                                                    | BIT(0);  /* 1G block */
+    } else {
+        /* Same 1 GiB block as the elfloader: reuse its PMD table. */
+        uart_block = (vaddr_t)uart_base & ~MASK(ARM_2MB_BLOCK_BITS);
+        _boot_pmd_down[GET_PMD_INDEX(uart_block)] = (uintptr_t)uart_block
+                                                    | BIT(10)  /* access flag */
+                                                    | (0 << 2) /* MT_DEVICE_nGnRnE */
+                                                    | BIT(0);  /* 2M block */
+        
+        /* Set one more 2MiB block to avoid alignment issues. */
+        uart_block += BIT(ARM_2MB_BLOCK_BITS);
+        _boot_pmd_down[GET_PMD_INDEX(uart_block)] = (uintptr_t)uart_block
+                                                    | BIT(10)  /* access flag */
+                                                    | (0 << 2) /* MT_DEVICE_nGnRnE */
+                                                    | BIT(0);  /* 2M block */
+    }
+}
+
 
 /*
 * Create the 1:1 elfloader mapping to jump into the kernel after enabling the MMU.
@@ -20,6 +59,7 @@ static void init_downpages(void)
     word_t i;
     vaddr_t start_vaddr = (vaddr_t)_text & ~MASK(ARM_2MB_BLOCK_BITS);
     vaddr_t end_vaddr = (vaddr_t)_end;
+    volatile void *uart_base = uart_get_mmio();
 
     _boot_pgd_down[0] = ((uintptr_t)_boot_pud_down) | BIT(1) | BIT(0); /* its a page table */
 
@@ -37,6 +77,13 @@ static void init_downpages(void)
                             | (4 << 2) /* MT_NORMAL memory */
                             | BIT(0);  /* 2M block */
         start_vaddr += BIT(ARM_2MB_BLOCK_BITS);
+    }
+
+    /* Identity-map the UART MMIO region so debug output works after the MMU
+     * is enabled.
+     */
+    if (uart_base != NULL) {
+        init_uart_downpages(GET_PUD_INDEX(start_vaddr), uart_base);
     }
 }
 


### PR DESCRIPTION
Previously el1 error traps defined in <arch>/<mode>/debug.c doesn't print anything cos the uart memory regions are not mapped after enabling mmu. This is a preliminary fix for arm aarch64 platforms.

# Limitations
Sorry that I have neither time nor hardware to implement and test this fix on other platforms.