### PR TITLE
elfloader: discard elf loader .eh_frame

### DIFF
--- a/elfloader-tool/src/linker.lds
+++ b/elfloader-tool/src/linker.lds
@@ -50,7 +50,7 @@ SECTIONS
     {
         . = ALIGN(0x1000);
         core_stack_alloc = .;
-        . = . + CONFIG_MAX_NUM_NODES * 1 << 12;
+        . = . + CONFIG_MAX_NUM_NODES * (1 << 12);
         core_stack_alloc_end = .;
         _bss = .;
         *(.sbss*)

--- a/elfloader-tool/src/linker.lds
+++ b/elfloader-tool/src/linker.lds
@@ -59,4 +59,13 @@ SECTIONS
         _bss_end = .;
     }
      _end = .;
+
+    /* With lld on riscv32 a debug-only non-empty .eh_frame ends up ahead of
+      .start, and OpenSBI always jumps to the first address. We could place it
+      somewhere explicitly, but discarding it for elfloader is easier and safe
+      (application payload is unaffected). */
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+    }
 }


### PR DESCRIPTION
- lld + clang on riscv32 generate a non-empty .eh_frame for libgcc.a with stack unwinding info for software-implemented div/mod. Other compiler + linker combinations only produce an empty .eh_frame (if at all).

  The non-empty .eh_frame ends up at the very beginning of the ELF file, displacing .start, and even though we are explicitly setting an entry point, OpenSBI is ignoring that entrypoint and just jumps to the first address, which no longer contains code. This means the boot hangs after OpenSBI.

  Placing the .eh_frame somewhere else explicitly fixes the problem, but we don't need it and discarding it is easier and more in line with what gcc produces. This affects the elfloader itself only, not the payload.

- disambiguate `x * 1 << 12` as `x * (1 << 12)`. I'm not sure if lld really interpreted this differently than GNU ld, but it is clearer in any case.

(Background of all of this is trying to get RISC-V clang builds in the new Trixie-based docker containers to work)