### PR TITLE
elf: ignore non-loadable segments for memory size

### DIFF
--- a/elfloader-tool/src/binaries/elf/elf.c
+++ b/elfloader-tool/src/binaries/elf/elf.c
@@ -220,6 +220,12 @@ int elf_getMemoryBounds(
     for (unsigned int i = 0; i < elf_getNumProgramHeaders(elfFile); i++) {
         uint64_t sect_min, sect_max;
 
+        /* Ignore non-loadable segments, they are either metadata or already
+           accounted for in PT_LOAD segments */
+        if (elf_getProgramHeaderType(elfFile, i) != PT_LOAD) {
+            continue;
+        }
+
         if (elf_getProgramHeaderMemorySize(elfFile, i) == 0) {
             continue;
         }


### PR DESCRIPTION
clang+lld for riscv produce a non-loadable `RISCV_ATTRIBUT` segment with non-zero size (on gcc+GNU ld it has size 0). This means `elf_getProgramHeaderMemorySize()` does not return 0, and the segment interferes with the memory size computation.

Only PT_LOAD segments are relevant for the memory layout anyway, so we ignore all non PT_LOAD segments.

A gcc build produces the following `elfloader` file:
```
Elf file type is EXEC (Executable file)
Entry point 0x81000000
There are 3 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  RISCV_ATTRIBUT 0x00000000002df138 0x0000000000000000 0x0000000000000000
                 0x000000000000006a 0x0000000000000000  R      0x1
  LOAD           0x0000000000001000 0x0000000081000000 0x0000000081000000
                 0x00000000002de138 0x00000000002e5000  RWE    0x1000
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10

 Section to Segment mapping:
  Segment Sections...
   00     .riscv.attributes 
   01     .start .text .rodata .data .bss 
   02 
```

The clang build produces
```
Elf file type is EXEC (Executable file)
Entry point 0x81000000
There are 4 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x0000000000001000 0x0000000081000000 0x0000000081000000
                 0x0000000000004e0e 0x0000000000004e0e  R E    0x1000
  LOAD           0x0000000000005e10 0x0000000081004e10 0x0000000081004e10
                 0x00000000002e32e8 0x00000000002ea1f0  RW     0x1000
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x0
  RISCV_ATTRIBUT 0x00000000002e90f8 0x0000000000000000 0x0000000000000000
                 0x0000000000000047 0x0000000000000047  R      0x1

 Section to Segment mapping:
  Segment Sections...
   00     .start .text 
   01     .rodata .data .bss 
   02     
   03     .riscv.attributes 
 ```