### PR TITLE
tx2/platform_init: add missing smc memory clobber

### DIFF
--- a/elfloader-tool/src/plat/tx2/platform_init.c
+++ b/elfloader-tool/src/plat/tx2/platform_init.c
@@ -53,7 +53,7 @@ static __attribute__((noinline)) int send_smc(uint8_t func, struct mce_regs *reg
         "stp x2, x3, [%1, #16 * 1]\n"
         : "+r"(ret)
         : "r"(regs)
-        : "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8",
+        : "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8",
         "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17");
     return ret;
 }


### PR DESCRIPTION
The inline assembly in the send_smc function in tx2/platform_init.c only declares clobbered registers, but not memory. This leads more recent gcc versions to optimize too aggressively.

Add missing memory clobber (as we have in other smc/sbi calls) for the regs struct that carries the result of the smc call.

This fixes the current CI boot hang for TX2 release builds.