### PR TITLE
gitlint: ignore length of Signed-off-by and URL lines

### DIFF
--- a/misc/.gitlint
+++ b/misc/.gitlint
@@ -46,3 +46,8 @@ regex=^trivial(.*)
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules
 ignore=B6
+
+[ignore-body-lines]
+# Ignore lines started with Co-authored-by, Signed-off-by
+# or lines containing a (possibly-space-indented) URL only.
+regex=(^Co-authored-by)|(^Signed-off-by)|(^\s*https?://\S+$)


### PR DESCRIPTION
Issue example:
  https://github.com/seL4/microkit/pull/488
Cross reference:
  https://github.com/jorisroovers/gitlint/issues/255
  https://jorisroovers.com/gitlint/latest/rules/builtin_rules/
  https://github.com/zulip/zulip-terminal/pull/1509

Specifically, this allows:

```
Co-authored-by: Someone whose name is too long to fit within 72 characters
Signed-off-by: Someone whose name is too long to fit within 72 characters
https://example.com/a/very/long/url/longer/than/72/chars
http://example.com/a/very/http/url/longer/than/72/chars
    http://example.com/an/indented/url
```

And does not allow (by not ignoring this case when text follows the URL)

```
https://example.com and continuing text that is longer than 72 characters.
```

There's a slight annoyance in the implementation of `ignore-body-lines` in that it screws with the line number reporting of errors.