### PR TITLE
application_settings: add UserOptimisation

### DIFF
--- a/cmake-tool/helpers/application_settings.cmake
+++ b/cmake-tool/helpers/application_settings.cmake
@@ -95,7 +95,19 @@ function(ApplyCommonSimulationSettings kernel_sel4_arch)
   endif()
 endfunction()
 
+# Set the optimisation level for user space for cmake RELEASE mode.
+# (The default cmake RELEASE flags otherwise are `-O3 -NDEBUG`).
+function(ApplyUserOptimisationSettings)
+  set(UserOptimisation "-O2" CACHE STRING "Set the user mode optimisation level")
+  set_property(CACHE UserOptimisation PROPERTY STRINGS "-O2;-Os;-O0;-O1;-O3")
+  set(CMAKE_C_FLAGS_RELEASE "${UserOptimisation} -DNDEBUG" CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS_RELEASE "${UserOptimisation} -DNDEBUG" CACHE STRING "" FORCE)
+  set(CMAKE_ASM_FLAGS_RELEASE "${UserOptimisation} -DNDEBUG" CACHE STRING "" FORCE)
+endfunction()
+
 function(ApplyCommonReleaseVerificationSettings release verification)
+  ApplyUserOptimisationSettings()
+
   # Setup flags for different combinations of 'release' (performance optimized builds) and
   # 'verification' (verification friendly features) builds
   if(release)


### PR DESCRIPTION
Add `UserOptimisation` setting that determines user space compiler optimisation level for CMake RELEASE mode and `ApplyUserOptimisationSettings ()` function to apply the setting.

Default CMake RELEASE mode settings are `-O3 -DNDEBUG`, so the function also sets `-DNDEBUG`.

Default to -O2, because -O3 tends to be too aggressive.

Apply by default in `ApplyCommonReleaseVerificationSettings()` which is used in all seL4 tooling projects.

This might fix https://github.com/seL4/seL4/issues/1436 